### PR TITLE
Added ability to handle command line args in scenarios

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "_3p-lua/toml"]
 	path = _3p-lua/toml
 	url = https://github.com/LebJe/toml.lua.git
+[submodule "_3p-lua/argparse"]
+	path = _3p-lua/argparse
+	url = https://github.com/mpeterv/argparse

--- a/cmake/LuaModules.cmake
+++ b/cmake/LuaModules.cmake
@@ -1,5 +1,6 @@
 
 INSTALL(FILES _3p-lua/inspect/inspect.lua DESTINATION scripts_3p)
+INSTALL(FILES _3p-lua/argparse/src/argparse.lua DESTINATION scripts_3p)
 
 SET(TOML_LUA_SOURCES
 _3p-lua/toml/src/toml.cpp

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,10 +34,7 @@ To run it, execute the following command:
 
 ```bash
 cd stormweaver
-# PGROOT is only needed when testing a specific PostgreSQL installation,
-# otherwise uses binaries available in $PATH
-export PGROOT="/path/to/the/pg/folder/"
-bin/stormweaver scenarios/example.lua
+bin/stormweaver scenarios/example.lua [-c config/stormweaver.toml] [-i /path/to/the/pg/folder/] [scenario specific arguments...]
 ```
 
 This script will:

--- a/docs/scripting-architecture.md
+++ b/docs/scripting-architecture.md
@@ -20,13 +20,20 @@ Lua scripts are stored in two directories:
 Additional, several 3rd party lua libraries are also included and are usable by scripts/scenarios.
 These are the following:
 
+* [argparse](https://github.com/mpeterv/argparse) for command line arguments
 * [inspect.lua](https://github.com/kikito/inspect.lua) for dumping lua objects
 * [toml.lua](https://github.com/LebJe/toml.lua) for dealing with config file
 
 ## C++ binding
 
 Stormweaver includes several classes/functions implemented in C++, which are usable in lua scripts.
-The complete list of these functions is available in the [Lua reference](lua-reference.md).
+The complete list of these functions is available in the [Lua C++ reference](lua-cpp-reference.md).
+
+## Scenario configuration
+
+The `argparse` library is included, and the C++ runner forwards all arguments to the script, including the scenario filename.
+
+The lua helpers already create a default parser using the global variable `argparser`, which includes handling the common arguments, so scenarios only have to set up additional scenario specific arguments.
 
 ## Multi-threaded structure
 

--- a/docs/scripting-examples.md
+++ b/docs/scripting-examples.md
@@ -1,5 +1,47 @@
 # Scripting examples
 
+## Minimal scenario
+
+```lua
+require("common")
+
+function setup_tables(worker)
+	worker:create_random_tables(5)
+	worker:generate_initial_data()
+end
+
+function main(argv)
+	args = argparser:parse(argv)
+	conffile = parse_config(args)
+	pgconfig = PgConf.new(conffile["default"])
+
+	pgm = PgManager.new(pgconfig)
+	pgm:setupAndStartPrimary()
+	pgm.primaryNode:init(setup_tables)
+
+	pg1 = pgm:get(1)
+
+	t1 = pgm.primaryNode:initRandomWorkload({ run_seconds = 20, worker_count = 5 })
+	t1:run()
+	t1:wait_completion()
+end
+```
+
+## Custom arguments
+
+A complete documentation for `argparse` is available at [https://argparse.readthedocs.io/](https://argparse.readthedocs.io/)
+
+```lua
+
+-- could also be in main
+argparser:option("-f --foo", "A sample option.", "bar")
+
+function main(argv)
+	args = argparser:parse(argv)
+    info("Foo: " .. inspect(args["foo"]))
+end
+```
+
 ## Simple postgres manager
 
 It is easy and simple to setup (replicated) PostgreSQL using `PgManager`:
@@ -47,7 +89,7 @@ function bg_thread()
     end
 end
 
-function main()
+function main(argv)
 
     info("Starting background thread...")
 

--- a/scenarios/pg1468-simplified.lua
+++ b/scenarios/pg1468-simplified.lua
@@ -14,13 +14,13 @@ function conn_settings(sqlconn)
 	sqlconn:execute_query("SET default_table_access_method=tde_heap;")
 end
 
-function main()
-	confdir = getenv("SWCONF", "config/")
-	conffile = toml.decodeFromFile(confdir .. "/stormweaver.toml")
+function main(argv)
+	args = argparser:parse(argv)
+	conffile = parse_config(args)
 	pgconfig = PgConf.new(conffile["default"])
 
 	pgm = PgManager.new(pgconfig)
-	pgm:setupAndStartPrimary()
+	pgm:setupAndStartPrimary(conn_settings)
 	pgm.primaryNode:init(setup_tables)
 
 	pg1 = pgm:get(1)

--- a/scenarios/pg1468.lua
+++ b/scenarios/pg1468.lua
@@ -49,16 +49,16 @@ function setupAdditionalActions()
 	--defaultActionRegistry():makeCustomSqlAction("as2", "ALTER SYSTEM SET pg_tde.wal_encrypt = off;", 10)
 end
 
-function main()
+function main(argv)
 	setupAdditionalActions()
 
-	confdir = getenv("SWCONF", "config/")
-	conffile = toml.decodeFromFile(confdir .. "/stormweaver.toml")
+	args = argparser:parse(argv)
+	conffile = parse_config(args)
 	pgconfig = PgConf.new(conffile["default"])
 
 	pgm = PgManager.new(pgconfig)
-	pgm:setupAndStartPrimary()
-	pgm:setupAndStartAReplica()
+	pgm:setupAndStartPrimary(conn_settings)
+	pgm:setupAndStartAReplica(conn_settings)
 
 	pgm.primaryNode:init(setup_tables)
 

--- a/scripts/PgConf.lua
+++ b/scripts/PgConf.lua
@@ -14,11 +14,7 @@ function module:nextPort()
 end
 
 function module:pgroot()
-	conf_value = self.config["pgroot"]
-	if conf_value == nil then
-		conf_value = ""
-	end
-	return getenv("PGROOT", self.config["pgroot"])
+	return self.config["pgroot"]
 end
 
 function module:datadirPath(datadir)

--- a/scripts/PgManager.lua
+++ b/scripts/PgManager.lua
@@ -45,7 +45,7 @@ function module:connect(index, user, db, conn_callback)
 	})
 end
 
-function module:setupAndStartPrimary()
+function module:setupAndStartPrimary(connectionCallback)
 	if primary_setup == true then
 		error("setupPrimary called multiple times")
 	end
@@ -77,7 +77,7 @@ function module:setupAndStartPrimary()
 	self:createdb("stormweaver")
 	self:createuser("stormweaver", { "-s" })
 
-	self.primaryNode = self:connect(1, "stormweaver", "stormweaver", conn_settings)
+	self.primaryNode = self:connect(1, "stormweaver", "stormweaver", connectionCallback)
 	self.primaryNode:init(function(worker)
 		worker:sql_connection():execute_query("CREATE USER repuser replication; SELECT pg_reload_conf();")
 	end)
@@ -85,9 +85,9 @@ function module:setupAndStartPrimary()
 	return primaryIdx
 end
 
-function module:setupAndStartAReplica()
+function module:setupAndStartAReplica(connectionCallback)
 	if self.primaryReplNode == nil then
-		self.primaryReplNode = self:connect(1, "repuser", "stormweaver", conn_settings)
+		self.primaryReplNode = self:connect(1, "repuser", "stormweaver", connectionCallback)
 	end
 
 	replicaId = tostring(self.nextReplica)

--- a/scripts/argparser.lua
+++ b/scripts/argparser.lua
@@ -1,0 +1,20 @@
+local argparse = require("argparse")
+
+argparser = argparse("stormweaver", "")
+argparser:argument("scenario", "Scenario file")
+argparser:option("-c --config", "Configuration file.", "config/stormweaver.toml")
+argparser:option(
+	"-i --install_dir",
+	"PostgreSQL installation directory (if specified, overrides configuration value for default server)",
+	""
+)
+
+function parse_config(args)
+	conffile = toml.decodeFromFile(args["config"])
+	if string.len(args["install_dir"]) > 0 then
+		info("Overriding default postgres installation directory with " .. args["install_dir"])
+		conffile["default"]["pgroot"] = args["install_dir"]
+	end
+
+	return conffile
+end

--- a/scripts/common.lua
+++ b/scripts/common.lua
@@ -2,6 +2,8 @@
 -- for example, debug(inspect(variablename))
 inspect = require("inspect")
 
+require("argparser")
+
 -- not required: module automatically injected by C++ code
 -- toml = require 'toml'
 

--- a/stormweaver/src/main.cpp
+++ b/stormweaver/src/main.cpp
@@ -1,4 +1,5 @@
 
+#include <span>
 #include <spdlog/spdlog.h>
 
 #include "scripting/luactx.hpp"
@@ -18,6 +19,8 @@ int main(int argc, char **argv) {
 
   ctx.loadScript(argv[1]);
 
+  const std::span remaining_args(argv + 1, argc - 1);
+
   auto &lua = ctx.ctx();
 
   // run main function
@@ -26,7 +29,7 @@ int main(int argc, char **argv) {
 
   if (script_main.valid()) {
     spdlog::info("Starting lua main");
-    sol::protected_function_result main_result = script_main();
+    sol::protected_function_result main_result = script_main(remaining_args);
     if (!main_result.valid()) {
       sol::error err = main_result;
       spdlog::error("Scenario script main function failed: {}", err.what());


### PR DESCRIPTION
Also moved the configuration logic to rely on command line arguments instead of environment variables, both for the configuration file customization and specifying the postgres installation location.

This should be simpler to use than the previous environment variable approach, but environment variables with getenv are still available to scenarios.