### PR TITLE
Added a simple CI test with Postgres

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,11 +13,11 @@ on:
         type: string
 env:
   CC: ${{ inputs.compiler }}
-  CXX: ${{ inputs.compiler == 'clang' && 'clang++' || 'g++' }}
+  CXX: ${{ inputs.compiler == 'clang-19' && 'clang++-19' || 'g++' }}
       
 jobs:
   build:
-    name: Build
+    name: Build and test
     runs-on: ubuntu-${{ inputs.ubuntu_version }}.04
     steps:
 
@@ -28,6 +28,8 @@ jobs:
           sudo apt-get install -y python3-full pipx cmake ninja-build
           pipx ensurepath
           sudo pipx install conan
+          sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+          sudo apt install clang-tools-19
 
       - name: Setup conan
         run: |
@@ -53,6 +55,10 @@ jobs:
         run: |
           conan build . --settings=build_type=${{ inputs.build_type }}
         working-directory: src/stormweaver
+
+      - name: Install PostgreSQL
+        run: |
+          sudo apt install postgresql
 
       - name: Run CTest
         run: |
@@ -84,34 +90,11 @@ jobs:
           name: release_${{ inputs.build_type }}_${{inputs.ubuntu_version }}_${{ inputs.compiler }}
           path: tars
 
-  test:
-    name: Test release tarball (disabled, todo)
-    runs-on: ubuntu-${{ inputs.ubuntu_version }}.04
-    needs: build
-    steps:
-
-      - name: Create directory
-        run: |
-          mkdir stormweaver
-
-      - name: Get artifact
-        uses: actions/download-artifact@v4
+      - name: Report on test fail
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
         with:
-          name: release_${{ inputs.build_type }}_${{inputs.ubuntu_version }}_${{ inputs.compiler }}
-          path: stormweaver/
-
-      - name: Setup MySQL
-        run: |
-          sudo apt install mysql-server
-          sudo systemctl start mysql.service
-          mysql -u root -proot -e "CREATE DATABASE test";
-
-      - name: Extract artifact
-        run: |
-          tar -xf *.tar.gz
-        working-directory: stormweaver
-
-      - name: Run quick stormweaver test
-        run: |
-          #bin/stormweaver --flavor mysql --tables 30 --logdir=$PWD/log --records 200 --threads 10 --seconds 20 --insert-row 100 --update-with-cond 50 --no-delete --log-failed-queries --log-all-queries --no-encryption --address 127.0.0.1 --password root
-        working-directory: stormweaver
+          name: testlog_${{ inputs.build_type }}_${{inputs.ubuntu_version }}_${{ inputs.compiler }}
+          path: |
+            src/stormweaver/logs/
+          retention-days: 3

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -11,7 +11,8 @@ jobs:
       matrix:
         ubuntu_version: [22,24]
         build_type: [Debug,RelWithDebInfo]
-        compiler: [gcc, clang]
+        compiler: [gcc, clang-19]
+      fail-fast: false
     uses: ./.github/workflows/build-and-test.yml
     with:
       ubuntu_version: ${{ matrix.ubuntu_version }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,4 +65,4 @@ INCLUDE(LuaModules)
 
 add_subdirectory(libstormweaver)
 add_subdirectory(stormweaver)
-
+add_subdirectory(tests)

--- a/docs/lua-cpp-reference.md
+++ b/docs/lua-cpp-reference.md
@@ -175,7 +175,15 @@ end
 Copies the directory recursively
 
 ```lua
-fs.delete_directory('from', 'to')
+fs.copy_directory('from', 'to')
+```
+
+### create_directory
+
+Creates a new directory recursively
+
+```lua
+fs.create_directory('path/to/the/new/dir')
 ```
 
 ### delete_directory

--- a/docs/scripting-architecture.md
+++ b/docs/scripting-architecture.md
@@ -15,6 +15,11 @@ Lua scripts are stored in two directories:
 * `scenarios` is intended for specific test scenarios
 * `scripts` is intended for helper functions/classes usable by multiple scenarios
 
+These directories are added to the search path at two locations:
+
+* Relative to the executable (which is `bin/stormweaver`, the directories have to be in the same folder as `bin`)
+* Relative to the current working directory
+
 ## 3rd party libraries
 
 Additional, several 3rd party lua libraries are also included and are usable by scripts/scenarios.

--- a/libstormweaver/src/process/postgres.cpp
+++ b/libstormweaver/src/process/postgres.cpp
@@ -168,7 +168,7 @@ bool Postgres::is_running() {
 bool Postgres::is_ready() {
   return BackgroundProcess::runAndWait(
              logger, fmt::format("{}/bin/pg_isready", installDir.string()),
-             {"-p", port}) == 0;
+             {"-h", "127.0.0.1", "-p", port}) == 0;
 }
 
 bool Postgres::wait_ready(std::size_t maxWaitTime) {
@@ -195,12 +195,14 @@ void Postgres::add_hba(std::string const &host, std::string const &database,
 bool Postgres::createdb(std::string const &name) {
   return BackgroundProcess::runAndWait(
              logger, fmt::format("{}/bin/createdb", installDir.string()),
-             {"-p", port, name}) == 0;
+             {"-h", "127.0.0.1", "-p", port, name}) == 0;
 }
 
 bool Postgres::createuser(std::string const &name, args_t args) {
   args.push_back("-p");
   args.push_back(port);
+  args.push_back("-h");
+  args.push_back("127.0.0.1");
   args.push_back(name);
   return BackgroundProcess::runAndWait(
              logger, fmt::format("{}/bin/createuser", installDir.string()),
@@ -210,7 +212,7 @@ bool Postgres::createuser(std::string const &name, args_t args) {
 bool Postgres::dropdb(std::string const &name) {
   return BackgroundProcess::runAndWait(
              logger, fmt::format("{}/bin/dropdb", installDir.string()),
-             {"-p", port, name}) == 0;
+             {"-h", "127.0.0.1", "-p", port, name}) == 0;
 }
 
 Postgres::~Postgres() { stop(10); }

--- a/libstormweaver/src/scripting/luactx.cpp
+++ b/libstormweaver/src/scripting/luactx.cpp
@@ -219,6 +219,9 @@ LuaContext::LuaContext(std::shared_ptr<spdlog::logger> logger)
   fs_usertype["delete_directory"] = [](std::string const &dir) {
     return std::filesystem::remove_all(dir);
   };
+  fs_usertype["create_directory"] = [](std::string const &path) {
+    return std::filesystem::create_directories(path);
+  };
 }
 
 sol::state &LuaContext::ctx() { return luaState; }

--- a/scenarios/basic.lua
+++ b/scenarios/basic.lua
@@ -47,7 +47,7 @@ function main(argv)
 
 	-- The PgManager class has helpers for setting up and managing a replication chain
 	pgm = PgManager.new(pgconfig)
-	pgm:setupAndStartPrimary(conn_settings)
+	pgm:setupAndStartPrimary(conn_setting, { shared_preload_libraries = "pg_tde" })
 
 	-- Modifies the default registry again, but the node already copied the default registry above
 	-- this doesn't affect the existing node

--- a/scenarios/pg1468-simplified.lua
+++ b/scenarios/pg1468-simplified.lua
@@ -20,7 +20,7 @@ function main(argv)
 	pgconfig = PgConf.new(conffile["default"])
 
 	pgm = PgManager.new(pgconfig)
-	pgm:setupAndStartPrimary(conn_settings)
+	pgm:setupAndStartPrimary(conn_settings, { shared_preload_libraries = "pg_tde" })
 	pgm.primaryNode:init(setup_tables)
 
 	pg1 = pgm:get(1)

--- a/scenarios/pg1468.lua
+++ b/scenarios/pg1468.lua
@@ -50,6 +50,14 @@ function setupAdditionalActions()
 end
 
 function main(argv)
+	-- tde setup: off / unencrypted default tables / on
+	--
+	-- replication options:
+	-- * tde setup before / after replica start
+	-- * killing or restarting or both primary
+	-- * killing or restarting or both replica(s)
+	-- * how many replicas?
+	-- * what type of queries to run?
 	setupAdditionalActions()
 
 	args = argparser:parse(argv)
@@ -57,8 +65,8 @@ function main(argv)
 	pgconfig = PgConf.new(conffile["default"])
 
 	pgm = PgManager.new(pgconfig)
-	pgm:setupAndStartPrimary(conn_settings)
-	pgm:setupAndStartAReplica(conn_settings)
+	pgm:setupAndStartPrimary(conn_settings, { shared_preload_libraries = "pg_tde" })
+	pgm:setupAndStartAReplica(conn_settings, { shared_preload_libraries = "pg_tde" })
 
 	pgm.primaryNode:init(setup_tables)
 

--- a/scripts/argparser.lua
+++ b/scripts/argparser.lua
@@ -8,6 +8,17 @@ argparser:option(
 	"PostgreSQL installation directory (if specified, overrides configuration value for default server)",
 	""
 )
+argparser:option("--include", "Extends the lua package path with the specified directories", ""):count("*")
+
+function parse_args(argv)
+	args = argparser:parse(argv)
+
+	for k, v in pairs(args["include"]) do
+		package.path = v .. "/?.lua;" .. package.path
+	end
+
+	return args
+end
 
 function parse_config(args)
 	conffile = toml.decodeFromFile(args["config"])

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,33 @@
+set("TEST_PG_DIR" "" CACHE STRING "Postgres installation directory used for testing")
+
+if("${TEST_PG_DIR}" STREQUAL "")
+    message("TEST_PG_DIR is empty, trying to autodetect")
+    set(POSSIBLE_PG_VERS 17 16 15 14)
+    foreach(ver ${POSSIBLE_PG_VERS})
+        set(dir "/usr/lib/postgresql/${ver}")
+        if(EXISTS "${dir}")
+            message("Setting TEST_PG_DIR to ${dir}")
+            set("TEST_PG_DIR" "${dir}")
+            break()
+        endif()
+    endforeach()
+endif()
+
+if("${TEST_PG_DIR}" STREQUAL "")
+    message(WARNING "TEST_PG_DIR is empty and couldn't be autodetected, skipping tests")
+endif()
+
+if(NOT "${TEST_PG_DIR}" STREQUAL "")
+
+    set(TEST_SCENARIOS
+        background
+        simple-pg
+    )
+
+    foreach(test ${TEST_SCENARIOS})
+        add_test(NAME stormweaver-${test}
+		COMMAND stormweaver "${CMAKE_SOURCE_DIR}/tests/${test}.lua" "-i" "${TEST_PG_DIR}"
+                WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+    endforeach()
+
+endif()

--- a/tests/simple-pg.lua
+++ b/tests/simple-pg.lua
@@ -1,0 +1,25 @@
+package.path = "scripts/?.lua;scripts_3p/?.lua;" .. package.path
+
+require("common")
+function db_setup(worker)
+	worker:create_random_tables(5)
+	worker:generate_initial_data()
+end
+
+function main(argv)
+	args = parse_args(argv)
+	conffile = parse_config(args)
+	pgconfig = PgConf.new(conffile["default"])
+
+	pgm = PgManager.new(pgconfig)
+	pgm:setupAndStartPrimary()
+
+	pgm.primaryNode:init(db_setup)
+
+	t1 = pgm.primaryNode:initRandomWorkload({ run_seconds = 10, worker_count = 2 })
+
+	t1:run()
+	t1:wait_completion()
+
+	pgm:get(1):stop(10)
+end


### PR DESCRIPTION
This is also part of the normal CTest workflow now, it accepts a TEST_PG_DIR option, or if it isn't specified it tries to autodetect if Postgres is installed on the system, and uses the latest version if found.

In relation to this, the server setup and command execution code now also works with Ubuntu packages, not just self-built binaries. This is generally useful for testing upstream.

Additionally the executable now not only looks for lua scripts at the location of the binary, but also in the current working directory, limited to the same `scripts` and `scripts_3p` directories. This is required because CTest runs before installation, and otherwise the stadard lua scripts wouldn't be usable in these tests.