### PR TITLE
Rename table action with basic tests for SQL actions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,25 @@ INCLUDE(PQSetupCompiler)
 INCLUDE(PQCPack)
 INCLUDE(PQFindRevision)
 
+set("TEST_PG_DIR" "" CACHE STRING "Postgres installation directory used for testing")
+
+if("${TEST_PG_DIR}" STREQUAL "")
+    message("TEST_PG_DIR is empty, trying to autodetect")
+    set(POSSIBLE_PG_VERS 17 16 15 14)
+    foreach(ver ${POSSIBLE_PG_VERS})
+        set(dir "/usr/lib/postgresql/${ver}")
+        if(EXISTS "${dir}")
+            message("Setting TEST_PG_DIR to ${dir}")
+            set("TEST_PG_DIR" "${dir}")
+            break()
+        endif()
+    endforeach()
+endif()
+
+if("${TEST_PG_DIR}" STREQUAL "")
+	message(WARNING "TEST_PG_DIR is empty and couldn't be autodetected, skipping SQL tests")
+endif()
+
 INCLUDE(LuaModules)
 
 add_subdirectory(libstormweaver)

--- a/libstormweaver/CMakeLists.txt
+++ b/libstormweaver/CMakeLists.txt
@@ -1,3 +1,4 @@
 
 ADD_SUBDIRECTORY(src)
 ADD_SUBDIRECTORY(test/unit)
+ADD_SUBDIRECTORY(test/sql)

--- a/libstormweaver/include/action/ddl.hpp
+++ b/libstormweaver/include/action/ddl.hpp
@@ -58,4 +58,15 @@ private:
   BitFlags<AlterSubcommand> possibleCommands;
 };
 
+class RenameTable : public Action {
+public:
+  RenameTable(DdlConfig const &config);
+
+  void execute(metadata::Metadata &metaCtx, ps_random &rand,
+               sql_variant::LoggedSQL *connection) const override;
+
+private:
+  DdlConfig config;
+};
+
 }; // namespace action

--- a/libstormweaver/include/bitflags.hpp
+++ b/libstormweaver/include/bitflags.hpp
@@ -49,9 +49,15 @@ public:
     return (flags_ & ToUnderlying(v)) == ToUnderlying(v);
   }
   // Sets a single flag value.
-  constexpr void Set(T v) { flags_ |= ToUnderlying(v); }
+  constexpr BitFlags &Set(T v) {
+    flags_ |= ToUnderlying(v);
+    return *this;
+  }
   // Unsets a single flag value.
-  constexpr void Unset(T v) { flags_ &= ~ToUnderlying(v); }
+  constexpr BitFlags &Unset(T v) {
+    flags_ &= ~ToUnderlying(v);
+    return *this;
+  }
   // Clears all flag values.
   constexpr void Clear() { flags_ = static_cast<UnderlyingT>(0); }
 

--- a/libstormweaver/include/process/postgres.hpp
+++ b/libstormweaver/include/process/postgres.hpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <spdlog/spdlog.h>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -26,6 +27,7 @@ public:
   ~Postgres();
 
   void add_config(params_t additionalConfig);
+  void add_config(std::string_view name, std::string_view value);
 
   void add_hba(std::string const &host, std::string const &database,
                std::string const &user, std::string const &address,

--- a/libstormweaver/include/sql_variant/generic.hpp
+++ b/libstormweaver/include/sql_variant/generic.hpp
@@ -66,7 +66,6 @@ struct ServerParams {
   std::string username;
   std::string password;
 
-  std::uint64_t maxpacket;
   std::uint16_t port;
 };
 

--- a/libstormweaver/src/action/action_registry.cpp
+++ b/libstormweaver/src/action/action_registry.cpp
@@ -29,6 +29,12 @@ ActionFactory alterTable{"alter_table",
                          },
                          100};
 
+ActionFactory renameTable{"rename_table",
+                          [](AllConfig const &config) {
+                            return std::make_unique<RenameTable>(config.ddl);
+                          },
+                          100};
+
 ActionFactory insertSomeData{"insert_some_data",
                              [](AllConfig const &config) {
                                return std::make_unique<InsertData>(config.dml,
@@ -54,6 +60,7 @@ ActionRegistry initializeDefaultRegisty() {
   ar.insert(createNormalTable);
   ar.insert(dropTable);
   ar.insert(alterTable);
+  ar.insert(renameTable);
   ar.insert(insertSomeData);
   ar.insert(deleteSomeData);
   ar.insert(updateOneRow);

--- a/libstormweaver/src/process/postgres.cpp
+++ b/libstormweaver/src/process/postgres.cpp
@@ -150,6 +150,15 @@ Postgres::Postgres(std::string const &logname, std::string const &installDir,
   }
 }
 
+void Postgres::add_config(std::string_view name, std::string_view value) {
+  std::ofstream stream(fmt::format("{}/postgresql.conf", dataDir.string()),
+                       std::ios_base::app);
+  stream << fmt::format("{} = {}", name, value) << std::endl;
+  if (name == "port") {
+    port = value;
+  }
+}
+
 void Postgres::add_config(params_t additionalConfig) {
   std::ofstream stream(fmt::format("{}/postgresql.conf", dataDir.string()),
                        std::ios_base::app);

--- a/libstormweaver/src/scripting/luactx.cpp
+++ b/libstormweaver/src/scripting/luactx.cpp
@@ -147,7 +147,9 @@ LuaContext::LuaContext(std::shared_ptr<spdlog::logger> logger)
   postgres_usertype["serverPort"] = &process::Postgres::serverPort;
   postgres_usertype["is_ready"] = &process::Postgres::is_ready;
   postgres_usertype["wait_ready"] = &process::Postgres::wait_ready;
-  postgres_usertype["add_config"] = &process::Postgres::add_config;
+  postgres_usertype["add_config"] =
+      static_cast<void (process::Postgres::*)(process::Postgres::params_t)>(
+          &process::Postgres::add_config);
   postgres_usertype["add_hba"] = &process::Postgres::add_hba;
 
   auto bg_t = luaState.new_usertype<BackgroundThread>("BackgroundThread",

--- a/libstormweaver/src/scripting/luactx.cpp
+++ b/libstormweaver/src/scripting/luactx.cpp
@@ -21,7 +21,7 @@ inline std::unique_ptr<Node> setup_node_pg(sol::table const &table) {
   spdlog::info("Setting up PG node on host: '{}', port: {}", host, port);
 
   return std::make_unique<Node>(SqlFactory(
-      sql_variant::ServerParams{database, host, "", user, password, 0, port},
+      sql_variant::ServerParams{database, host, "", user, password, port},
       [on_connect_lua](sql_variant::LoggedSQL const &sql) {
         if (on_connect_lua.valid()) {
           sol::protected_function_result result = on_connect_lua(&sql);

--- a/libstormweaver/test/sql/CMakeLists.txt
+++ b/libstormweaver/test/sql/CMakeLists.txt
@@ -1,0 +1,11 @@
+SET(SQLTEST_SOURCES
+    main.cpp
+    ddl.cpp
+)
+
+add_executable(test-stormweaver-sql ${SQLTEST_SOURCES})
+target_link_libraries(test-stormweaver-sql
+    Catch2::Catch2 libstormweaver
+)
+
+add_test(NAME test-stormweaver-sql COMMAND sh -c "mkdir -p ${CMAKE_BINARY_DIR}/test-reports && $<TARGET_FILE:test-stormweaver-sql> ${TEST_PG_DIR} ${CMAKE_BINARY_DIR}/test/sql-data 25432 --reporter=JUnit >${CMAKE_BINARY_DIR}/test-reports/test-stormweaver-sql.xml")

--- a/libstormweaver/test/sql/README.md
+++ b/libstormweaver/test/sql/README.md
@@ -1,0 +1,9 @@
+SQL tests
+
+The goal of these tests is to run simple single threaded deterministic threads againts a real SQL server, and make sure that we get no errors.
+
+The metadata/action system can result in failing SQLs, but this should only happen with (a) a database server bug (b) as a sideeffect of concurrency.
+
+A single threaded execution shouldn't result in any errors.
+
+This test just executes a few hundred SQL statements of each kind, and reports success if everything went well.

--- a/libstormweaver/test/sql/ddl.cpp
+++ b/libstormweaver/test/sql/ddl.cpp
@@ -1,0 +1,43 @@
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "action/ddl.hpp"
+#include "sql.hpp"
+
+namespace {
+struct Fixture {
+  mutable metadata::Metadata metaCtx;
+  mutable ps_random rand;
+  action::DdlConfig config;
+};
+
+} // namespace
+
+TEST_CASE_PERSISTENT_FIXTURE(Fixture, "DDLs work") {
+
+  SECTION("tables can be created") {
+
+    for (int i = 0; i < 100; ++i) {
+      action::CreateTable ct(config, metadata::Table::Type::normal);
+      REQUIRE_NOTHROW(ct.execute(metaCtx, rand, sqlConnection.get()));
+    }
+  }
+
+  SECTION("tables can be altered") {
+    for (int i = 0; i < 1000; ++i) {
+      // disable change access method, as this can be run againts upstream pg
+      // without tde
+      action::AlterTable at(config,
+                            BitFlags<action::AlterSubcommand>::AllSet().Unset(
+                                action::AlterSubcommand::changeAccessMethod));
+      REQUIRE_NOTHROW(at.execute(metaCtx, rand, sqlConnection.get()));
+    }
+  }
+
+  SECTION("tables can be dropped") {
+    for (int i = 0; i < 100; ++i) {
+      action::DropTable dt(config);
+      REQUIRE_NOTHROW(dt.execute(metaCtx, rand, sqlConnection.get()));
+    }
+  }
+}

--- a/libstormweaver/test/sql/ddl.cpp
+++ b/libstormweaver/test/sql/ddl.cpp
@@ -34,6 +34,13 @@ TEST_CASE_PERSISTENT_FIXTURE(Fixture, "DDLs work") {
     }
   }
 
+  SECTION("tables can be renamed") {
+    for (int i = 0; i < 100; ++i) {
+      action::RenameTable rt(config);
+      REQUIRE_NOTHROW(rt.execute(metaCtx, rand, sqlConnection.get()));
+    }
+  }
+
   SECTION("tables can be dropped") {
     for (int i = 0; i < 100; ++i) {
       action::DropTable dt(config);

--- a/libstormweaver/test/sql/main.cpp
+++ b/libstormweaver/test/sql/main.cpp
@@ -1,0 +1,72 @@
+#include "spdlog/sinks/stdout_color_sinks.h"
+#include "sql.hpp"
+#include <catch2/catch_session.hpp>
+#include <filesystem>
+#include <spdlog/spdlog.h>
+
+#include "process/postgres.hpp"
+#include "sql_variant/generic.hpp"
+#include "sql_variant/postgresql.hpp"
+
+std::unique_ptr<sql_variant::LoggedSQL> sqlConnection;
+
+using namespace std::literals;
+
+int main(int argc, char **argv) {
+
+  spdlog::set_level(spdlog::level::debug);
+  auto err_logger = spdlog::stderr_color_mt("stderr");
+  spdlog::set_default_logger(err_logger);
+
+  if (argc < 4) {
+    spdlog::error(
+        "Usage: {} <postgresInstallDir> <dataDir> <port> ... catch2 args ...",
+        argv[0]);
+    return 1;
+  }
+
+  const std::string postgresDir = argv[1];
+  const std::string dataDir = argv[2];
+  const std::string postgresPort = argv[3];
+
+  if (std::filesystem::is_directory(dataDir)) {
+    spdlog::warn("Data directory '{}' already exist, deleting.", dataDir);
+    std::filesystem::remove_all(dataDir);
+  }
+
+  process::Postgres pg(true, "test-stormweaver-sql", postgresDir, dataDir);
+  std::filesystem::create_directory(dataDir + "/sock");
+  pg.add_config("port", postgresPort);
+  pg.add_config("unix_socket_directories", "sock");
+  pg.add_config("logging_collector", "on");
+  pg.add_config("log_statement", "all");
+  pg.add_config("log_directory", "'logs'");
+  pg.add_config("log_filename", "'server.log'");
+  pg.add_config("log_min_messages", "'info'");
+
+  if (!pg.start("", {}) || !pg.wait_ready(60)) {
+    spdlog::error("Couldn't start postgres server, exiting");
+    return 2;
+  }
+
+  // TODO: pg sometimes fails if we do not have these sleeps
+  // "FATAL:  could not open file "global/pg_filenode.map": No such file or
+  // directory"
+  pg.createdb("sql_tests");
+  pg.createuser("stormweaver", {"-s"});
+
+  sqlConnection = std::make_unique<sql_variant::LoggedSQL>(
+      std::make_unique<sql_variant::PostgreSQL>(sql_variant::ServerParams{
+          "sql_tests", "127.0.0.1", "", "stormweaver", "",
+          static_cast<std::uint16_t>(std::stoi(postgresPort))}),
+      "test-stormweaver-sql-sqllog");
+
+  std::vector<char *> remaining_args;
+
+  remaining_args.push_back(argv[0]);
+  if (argc > 4) {
+    remaining_args.insert(remaining_args.end(), argv + 4, argv + argc);
+  }
+
+  return Catch::Session().run(remaining_args.size(), remaining_args.data());
+}

--- a/libstormweaver/test/sql/sql.hpp
+++ b/libstormweaver/test/sql/sql.hpp
@@ -1,0 +1,5 @@
+
+#include "sql_variant/generic.hpp"
+#include <memory>
+
+extern std::unique_ptr<sql_variant::LoggedSQL> sqlConnection;

--- a/libstormweaver/test/unit/CMakeLists.txt
+++ b/libstormweaver/test/unit/CMakeLists.txt
@@ -1,12 +1,11 @@
-
 SET(UNITTEST_SOURCES
     main.cpp
     metadata_test.cpp
 )
 
-add_executable(stormweaver-unit ${UNITTEST_SOURCES})
-target_link_libraries(stormweaver-unit
+add_executable(test-stormweaver-unit ${UNITTEST_SOURCES})
+target_link_libraries(test-stormweaver-unit
     Catch2::Catch2 libstormweaver
 )
 
-add_test(NAME stormweaver-unit COMMAND sh -c "mkdir -p ${CMAKE_BINARY_DIR}/test-reports && $<TARGET_FILE:stormweaver-unit> --reporter=JUnit >${CMAKE_BINARY_DIR}/test-reports/stormweaver-unit.xml")
+add_test(NAME test-stormweaver-unit COMMAND sh -c "mkdir -p ${CMAKE_BINARY_DIR}/test-reports && $<TARGET_FILE:test-stormweaver-unit> --reporter=JUnit >${CMAKE_BINARY_DIR}/test-reports/test-stormweaver-unit.xml")

--- a/libstormweaver/test/unit/main.cpp
+++ b/libstormweaver/test/unit/main.cpp
@@ -1,7 +1,5 @@
-
 #include <catch2/catch_session.hpp>
 
 int main(int argc, char **argv) {
-  // TODO: parse database config for database tests
   return Catch::Session().run(argc, argv); //
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,22 +1,3 @@
-set("TEST_PG_DIR" "" CACHE STRING "Postgres installation directory used for testing")
-
-if("${TEST_PG_DIR}" STREQUAL "")
-    message("TEST_PG_DIR is empty, trying to autodetect")
-    set(POSSIBLE_PG_VERS 17 16 15 14)
-    foreach(ver ${POSSIBLE_PG_VERS})
-        set(dir "/usr/lib/postgresql/${ver}")
-        if(EXISTS "${dir}")
-            message("Setting TEST_PG_DIR to ${dir}")
-            set("TEST_PG_DIR" "${dir}")
-            break()
-        endif()
-    endforeach()
-endif()
-
-if("${TEST_PG_DIR}" STREQUAL "")
-    message(WARNING "TEST_PG_DIR is empty and couldn't be autodetected, skipping tests")
-endif()
-
 if(NOT "${TEST_PG_DIR}" STREQUAL "")
 
     set(TEST_SCENARIOS


### PR DESCRIPTION
This PR adds a simple `alter table rename to` action, with a test framework for SQL actions and some basic tests for DDL actions in it.

It also fixes a bunch of issues in the previously existing actions detected by these tests.