### PR TITLE
Support foreign keys

### DIFF
--- a/docs/lua-cpp-reference.md
+++ b/docs/lua-cpp-reference.md
@@ -432,14 +432,6 @@ Currently the DDL configuration can't be modified.
 worker:create_random_tables(5)
 ```
 
-### generate_initial_data
-
-Generates some rows in all currently existing tables.
-
-```lua
-worker:generate_initial_data()
-```
-
 ### sql_connection
 
 Returns the SQL connection (LoggedSQL) of the worker, which can be used to execute SQL statements directly.

--- a/docs/scripting-examples.md
+++ b/docs/scripting-examples.md
@@ -7,7 +7,6 @@ require("common")
 
 function setup_tables(worker)
 	worker:create_random_tables(5)
-	worker:generate_initial_data()
 end
 
 function main(argv)

--- a/libstormweaver/include/action/action.hpp
+++ b/libstormweaver/include/action/action.hpp
@@ -20,4 +20,14 @@ public:
                        sql_variant::LoggedSQL *connection) const = 0;
 };
 
+class ActionException : public std::exception {
+public:
+  ActionException(std::string const &message) : message(message) {}
+
+  const char *what() const noexcept override { return message.c_str(); }
+
+private:
+  std::string message;
+};
+
 } // namespace action

--- a/libstormweaver/include/action/action_registry.hpp
+++ b/libstormweaver/include/action/action_registry.hpp
@@ -7,16 +7,6 @@
 
 namespace action {
 
-class ActionException : public std::exception {
-public:
-  ActionException(std::string const &message) : message(message) {}
-
-  const char *what() const noexcept override { return message.c_str(); }
-
-private:
-  std::string message;
-};
-
 using action_build_t =
     std::function<std::unique_ptr<action::Action>(action::AllConfig const &)>;
 

--- a/libstormweaver/include/action/all.hpp
+++ b/libstormweaver/include/action/all.hpp
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include "action/composite.hpp"
 #include "action/custom.hpp"
 #include "action/ddl.hpp"
 #include "action/dml.hpp"

--- a/libstormweaver/include/action/composite.hpp
+++ b/libstormweaver/include/action/composite.hpp
@@ -1,0 +1,72 @@
+
+#pragma once
+
+#include "action/action.hpp"
+
+#include <tuple>
+#include <utility>
+
+namespace action {
+
+template <typename T>
+concept usePointerSyntax =
+    requires(T a, metadata::Metadata &metaCtx, ps_random &rand,
+             sql_variant::LoggedSQL *connection) {
+      a->execute(metaCtx, rand, connection);
+    };
+
+template <typename Context, typename... ActionTs>
+class CompositeAction : public Action {
+public:
+  CompositeAction(Context &&ctx, ActionTs &&...actions)
+      : ctx(std::move(ctx)), actions(std::move(actions)...) {}
+
+  template <typename ActionT>
+  static void executeHelper(ActionT const &action, metadata::Metadata &metaCtx,
+                            ps_random &rand,
+                            sql_variant::LoggedSQL *connection) {
+    if constexpr (usePointerSyntax<ActionT>) {
+      action->execute(metaCtx, rand, connection);
+    } else {
+      action.execute(metaCtx, rand, connection);
+    }
+  }
+
+  void execute(metadata::Metadata &metaCtx, ps_random &rand,
+               sql_variant::LoggedSQL *connection) const override {
+    std::apply(
+        [&](const auto &...tupleArgs) {
+          (executeHelper(tupleArgs, metaCtx, rand, connection), ...);
+        },
+        actions);
+  }
+
+private:
+  // Context is just used by the composite setup, as a possible container for
+  // callbacks during the composite setup
+  Context ctx;
+  std::tuple<ActionTs...> actions;
+};
+
+template <typename ActionT> class RepeatAction : public Action {
+public:
+  RepeatAction(ActionT &&action, std::size_t repeatCount)
+      : action(std::move(action)), repeatCount(repeatCount) {}
+
+  void execute(metadata::Metadata &metaCtx, ps_random &rand,
+               sql_variant::LoggedSQL *connection) const override {
+    for (std::size_t idx = 0; idx < repeatCount; ++idx) {
+      if constexpr (usePointerSyntax<ActionT>) {
+        action->execute(metaCtx, rand, connection);
+      } else {
+        action.execute(metaCtx, rand, connection);
+      }
+    }
+  }
+
+private:
+  ActionT action;
+  std::size_t repeatCount;
+};
+
+} // namespace action

--- a/libstormweaver/include/action/ddl.hpp
+++ b/libstormweaver/include/action/ddl.hpp
@@ -4,6 +4,8 @@
 #include "action/action.hpp"
 #include "bitflags.hpp"
 
+#include <functional>
+
 namespace action {
 
 struct DdlConfig {
@@ -16,9 +18,13 @@ struct DdlConfig {
   std::vector<std::string> access_methods = {"heap", "tde_heap"};
 };
 
+using TableCallback = std::function<void(metadata::table_cptr ptr)>;
+
 class CreateTable : public Action {
 public:
   CreateTable(DdlConfig const &config, metadata::Table::Type type);
+
+  void setSuccessCallback(TableCallback const &cb);
 
   void execute(metadata::Metadata &metaCtx, ps_random &rand,
                sql_variant::LoggedSQL *connection) const override;
@@ -26,6 +32,7 @@ public:
 private:
   DdlConfig config;
   metadata::Table::Type type;
+  TableCallback successCallback;
 };
 
 class DropTable : public Action {

--- a/libstormweaver/include/action/ddl.hpp
+++ b/libstormweaver/include/action/ddl.hpp
@@ -15,6 +15,8 @@ struct DdlConfig {
   std::size_t max_alter_clauses = 5;
   std::size_t min_partition_count = 3;
   std::size_t max_partition_count = 10;
+  std::size_t ct_foreign_key_percentage =
+      50; // how many % of create tables will have foreign keys?
   std::vector<std::string> access_methods = {"heap", "tde_heap"};
 };
 

--- a/libstormweaver/include/action/dml.hpp
+++ b/libstormweaver/include/action/dml.hpp
@@ -3,12 +3,16 @@
 
 #include "action/action.hpp"
 
+#include <functional>
+
 namespace action {
 
 struct DmlConfig {
   std::size_t deleteMin = 1;
   std::size_t deleteMax = 100;
 };
+
+using TableLocator = std::function<metadata::table_cptr()>;
 
 class UpdateOneRow : public Action {
 public:
@@ -34,8 +38,8 @@ private:
 
 class InsertData : public Action {
 public:
-  InsertData(DmlConfig const &config, metadata::table_cptr table,
-             std::size_t rows);
+  InsertData(DmlConfig const &config, std::size_t rows,
+             TableLocator const &locator);
   InsertData(DmlConfig const &config, std::size_t rows);
 
   void execute(metadata::Metadata &metaCtx, ps_random &rand,
@@ -43,7 +47,7 @@ public:
 
 private:
   DmlConfig config;
-  metadata::table_cptr table;
+  TableLocator locator;
   std::size_t rows;
 };
 

--- a/libstormweaver/include/action/helper.hpp
+++ b/libstormweaver/include/action/helper.hpp
@@ -1,0 +1,12 @@
+
+#pragma once
+
+#include "action/action.hpp"
+#include "metadata.hpp"
+
+namespace action {
+
+metadata::table_cptr find_random_table(metadata::Metadata const &metaCtx,
+                                       ps_random &rand);
+
+}

--- a/libstormweaver/include/metadata.hpp
+++ b/libstormweaver/include/metadata.hpp
@@ -215,6 +215,7 @@ struct Column {
   bool nullable = false;
   bool primary_key = false;
   bool partition_key = false;
+  std::string foreign_key_references;
   bool auto_increment = false;
 };
 
@@ -261,6 +262,11 @@ struct Table {
   boost::container::small_vector<Column, limits::optimized_column_count>
       columns;
   boost::container::small_vector<Index, limits::optimized_index_count> indexes;
+
+  bool hasReferenceTo(std::string const &tableName) const;
+  void removeReferencesTo(std::string const &tableName);
+  void updateReferencesTo(std::string const &oldTableName,
+                          std::string const &newTableName);
 };
 
 using table_ptr = std::shared_ptr<Table>;

--- a/libstormweaver/include/workload.hpp
+++ b/libstormweaver/include/workload.hpp
@@ -34,8 +34,6 @@ public:
 
   void create_random_tables(std::size_t count);
 
-  void generate_initial_data();
-
   sql_variant::LoggedSQL *sql_connection() const;
 
   void reconnect();

--- a/libstormweaver/src/CMakeLists.txt
+++ b/libstormweaver/src/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY_SOURCES
     action/custom.cpp
     action/ddl.cpp
     action/dml.cpp
+    action/helper.cpp
     process/postgres.cpp
     process/process.cpp
     random.cpp

--- a/libstormweaver/src/action/ddl.cpp
+++ b/libstormweaver/src/action/ddl.cpp
@@ -292,7 +292,8 @@ void AlterTable::execute(Metadata &metaCtx, ps_random &rand,
             const bool numericColumn = col.type == metadata::ColumnType::INT ||
                                        col.type == metadata::ColumnType::REAL;
 
-            if (numericColumn && col.foreign_key_references.empty()) {
+            if (numericColumn && col.foreign_key_references.empty() &&
+                !col.primary_key) {
               alterSubcommands.emplace_back(
                   fmt::format("ALTER COLUMN {} TYPE VARCHAR(32)", col.name));
               availableColumns.erase(availableColumns.begin() + idx);

--- a/libstormweaver/src/action/ddl.cpp
+++ b/libstormweaver/src/action/ddl.cpp
@@ -234,6 +234,8 @@ void AlterTable::execute(Metadata &metaCtx, ps_random &rand,
           const auto columnIndexIndex =
               rand.random_number(std::size_t(0), availableColumns.size() - 1);
           const auto columnIndex = availableColumns[columnIndexIndex];
+          if (columnIndex == 0)
+            break; // do not try to drop the primary key
           alterSubcommands.emplace_back(
               fmt::format("DROP COLUMN {}", table->columns[columnIndex].name));
           droppedColumns.push_back(columnIndex);

--- a/libstormweaver/src/action/ddl.cpp
+++ b/libstormweaver/src/action/ddl.cpp
@@ -65,6 +65,10 @@ std::string columnDefinition(Column const &col) {
 CreateTable::CreateTable(DdlConfig const &config, Table::Type type)
     : config(config), type(type) {}
 
+void CreateTable::setSuccessCallback(TableCallback const &cb) {
+  successCallback = cb;
+}
+
 void CreateTable::execute(Metadata &metaCtx, ps_random &rand,
                           sql_variant::LoggedSQL *connection) const {
   if (metaCtx.size() >= config.max_table_count) {
@@ -155,6 +159,10 @@ void CreateTable::execute(Metadata &metaCtx, ps_random &rand,
     }
 
     res.complete();
+
+    if (successCallback) {
+      successCallback(table);
+    }
   });
 }
 

--- a/libstormweaver/src/action/dml.cpp
+++ b/libstormweaver/src/action/dml.cpp
@@ -24,6 +24,12 @@ std::string generate_value(metadata::Column const &col, ps_random &rand,
     return std::to_string(rp->ranges[range].rangebase * rp->rangeSize +
                           (num % rp->rangeSize));
   }
+  if (!col.foreign_key_references.empty()) {
+    // TODO: column name is hardcoded
+    return fmt::format("(SELECT id FROM {} ORDER BY random() LIMIT 1)",
+                       col.foreign_key_references);
+  }
+
   switch (col.type) {
   case metadata::ColumnType::INT:
     return std::to_string(rand.random_number(1, 1000000));

--- a/libstormweaver/src/action/dml.cpp
+++ b/libstormweaver/src/action/dml.cpp
@@ -1,5 +1,6 @@
 
 #include "action/dml.hpp"
+#include "action/helper.hpp"
 
 #include <boost/algorithm/string/join.hpp>
 #include <fmt/format.h>
@@ -52,15 +53,7 @@ InsertData::InsertData(DmlConfig const &config, std::size_t rows,
 void InsertData::execute(Metadata &metaCtx, ps_random &rand,
                          sql_variant::LoggedSQL *connection) const {
 
-  auto table = locator ? locator() : nullptr;
-
-  if (metaCtx.size() == 0)
-    return; // TODO: log
-  while (table == nullptr) {
-    // select a random table from metadata
-    std::size_t idx = rand.random_number<std::size_t>(0, metaCtx.size() - 1);
-    table = metaCtx[idx];
-  }
+  table_cptr table = find_random_table(metaCtx, rand);
 
   std::stringstream sql;
   sql << "INSERT INTO ";
@@ -106,16 +99,7 @@ DeleteData::DeleteData(DmlConfig const &config) : config(config) {}
 void DeleteData::execute(Metadata &metaCtx, ps_random &rand,
                          sql_variant::LoggedSQL *connection) const {
 
-  if (metaCtx.size() == 0)
-    return; // TODO: log
-
-  table_cptr table = nullptr;
-
-  while (table == nullptr) {
-    // select a random table from metadata
-    std::size_t idx = rand.random_number<std::size_t>(0, metaCtx.size() - 1);
-    table = metaCtx[idx];
-  }
+  table_cptr table = find_random_table(metaCtx, rand);
 
   auto const &tableName = table->name;
   // TODO: assumes we have a single column primary key as the first column.
@@ -136,16 +120,7 @@ UpdateOneRow::UpdateOneRow(DmlConfig const &config) : config(config) {}
 void UpdateOneRow::execute(Metadata &metaCtx, ps_random &rand,
                            sql_variant::LoggedSQL *connection) const {
 
-  if (metaCtx.size() == 0)
-    return; // TODO: log
-
-  table_cptr table = nullptr;
-
-  while (table == nullptr) {
-    // select a random table from metadata
-    std::size_t idx = rand.random_number<std::size_t>(0, metaCtx.size() - 1);
-    table = metaCtx[idx];
-  }
+  table_cptr table = find_random_table(metaCtx, rand);
 
   auto const &tableName = table->name;
   // TODO: assumes we have a single column primary key as the first column.

--- a/libstormweaver/src/action/dml.cpp
+++ b/libstormweaver/src/action/dml.cpp
@@ -43,16 +43,16 @@ std::string generate_value(metadata::Column const &col, ps_random &rand,
 }; // namespace
 
 InsertData::InsertData(DmlConfig const &config, std::size_t rows)
-    : config(config), table(nullptr), rows(rows) {}
+    : config(config), rows(rows) {}
 
-InsertData::InsertData(DmlConfig const &config, metadata::table_cptr table,
-                       std::size_t rows)
-    : config(config), table(table), rows(rows) {}
+InsertData::InsertData(DmlConfig const &config, std::size_t rows,
+                       TableLocator const &locator)
+    : config(config), locator(locator), rows(rows) {}
 
 void InsertData::execute(Metadata &metaCtx, ps_random &rand,
                          sql_variant::LoggedSQL *connection) const {
 
-  auto table = this->table;
+  auto table = locator ? locator() : nullptr;
 
   if (metaCtx.size() == 0)
     return; // TODO: log

--- a/libstormweaver/src/action/helper.cpp
+++ b/libstormweaver/src/action/helper.cpp
@@ -1,0 +1,24 @@
+
+#include "action/helper.hpp"
+#include "action/action.hpp"
+
+namespace action {
+
+metadata::table_cptr find_random_table(metadata::Metadata const &metaCtx,
+                                       ps_random &rand) {
+  if (metaCtx.size() == 0)
+    throw ActionException("Can't find random table: metadata is empty");
+
+  for (int i = 0; i < 10; ++i) {
+    // select a random table from metadata
+    std::size_t idx = rand.random_number<std::size_t>(0, metaCtx.size() - 1);
+    metadata::table_cptr table = metaCtx[idx];
+    if (table != nullptr) {
+      return table;
+    }
+  }
+
+  throw ActionException("Can't find random table: no result in 10 tries");
+}
+
+} // namespace action

--- a/libstormweaver/src/metadata.cpp
+++ b/libstormweaver/src/metadata.cpp
@@ -5,6 +5,28 @@
 
 namespace metadata {
 
+bool Table::hasReferenceTo(std::string const &tableName) const {
+  for (std::size_t idx = 0; idx < columns.size(); ++idx) {
+    if (columns[idx].foreign_key_references == tableName) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void Table::removeReferencesTo(std::string const &tableName) {
+  updateReferencesTo(tableName, "");
+}
+
+void Table::updateReferencesTo(std::string const &oldTableName,
+                               std::string const &newTableName) {
+  for (std::size_t idx = 0; idx < columns.size(); ++idx) {
+    if (columns[idx].foreign_key_references == oldTableName) {
+      columns[idx].foreign_key_references = newTableName;
+    }
+  }
+}
+
 Metadata::Reservation::Reservation()
     : storage_(nullptr), table_(nullptr), drop_(false), index_(Metadata::npos),
       lock_() {}

--- a/libstormweaver/src/scripting/luactx.cpp
+++ b/libstormweaver/src/scripting/luactx.cpp
@@ -122,13 +122,11 @@ LuaContext::LuaContext(std::shared_ptr<spdlog::logger> logger)
   auto worker_usertype =
       luaState.new_usertype<Worker>("Worker", sol::no_constructor);
   worker_usertype["create_random_tables"] = &Worker::create_random_tables;
-  worker_usertype["generate_initial_data"] = &Worker::generate_initial_data;
   worker_usertype["sql_connection"] = &Worker::sql_connection;
 
   luaState.new_usertype<RandomWorker>(
       "Worker", sol::no_constructor, "create_random_tables",
-      &RandomWorker::create_random_tables, "generate_initial_data",
-      &RandomWorker::generate_initial_data, "possibleActions",
+      &RandomWorker::create_random_tables, "possibleActions",
       &RandomWorker::possibleActions);
 
   auto workload_usertype =

--- a/libstormweaver/src/workload.cpp
+++ b/libstormweaver/src/workload.cpp
@@ -30,18 +30,6 @@ void Worker::create_random_tables(std::size_t count) {
   }
 }
 
-void Worker::generate_initial_data() {
-  for (std::size_t idx = 0; idx < metadata->size(); ++idx) {
-    auto table = (*metadata)[idx];
-    if (table) {
-      for (std::size_t i = 0; i < 10; ++i) {
-        action::InsertData inserter(config.actionConfig.dml, table, 100);
-        inserter.execute(*metadata.get(), rand, sql_conn.get());
-      }
-    }
-  }
-}
-
 sql_variant::LoggedSQL *Worker::sql_connection() const {
   return sql_conn.get();
 }

--- a/scenarios/basic.lua
+++ b/scenarios/basic.lua
@@ -19,7 +19,6 @@ function db_setup(worker)
 	init_pg_tde_only_for_db(worker:sql_connection())
 	-- or creating tables and loading some data
 	worker:create_random_tables(5)
-	worker:generate_initial_data() -- TODO: this method needs some parameters...
 end
 
 -- another callback function, called after establishing any database connection

--- a/scenarios/pg1468-simplified.lua
+++ b/scenarios/pg1468-simplified.lua
@@ -6,7 +6,6 @@ function setup_tables(worker)
 	-- comment out next line for non encrypted run
 	init_pg_tde_only_for_db(worker:sql_connection())
 	worker:create_random_tables(5)
-	worker:generate_initial_data()
 end
 
 function conn_settings(sqlconn)

--- a/scenarios/pg1468.lua
+++ b/scenarios/pg1468.lua
@@ -5,7 +5,6 @@ require("common")
 function setup_tables(worker)
 	init_pg_tde_globally(worker:sql_connection())
 	worker:create_random_tables(5)
-	worker:generate_initial_data()
 end
 
 function conn_settings(sqlconn)

--- a/tests/simple-pg.lua
+++ b/tests/simple-pg.lua
@@ -3,7 +3,6 @@ package.path = "scripts/?.lua;scripts_3p/?.lua;" .. package.path
 require("common")
 function db_setup(worker)
 	worker:create_random_tables(5)
-	worker:generate_initial_data()
 end
 
 function main(argv)


### PR DESCRIPTION
The goal of this PR is to add foreign keys to stormweaver tests. This is a prerequisite for later PRs/features, which will add complex selects / views / materialized views to the testing.

This PR includes several commits:

* Support for composite actions (e.g. CREATE and then INSERT) so that we create tables with some data in them by default
* Fix the primary keys of partitioned tables: the partition key is now also the primary key, it's the first column instead of the second, the only difference from normal primary keys is that it's not auto generated with a sequence
* Small refactoring: extract the random table selection logic into it's own helper from `dml.cpp`
* Improve drop column generation: do not drop primary keys. While this could be a useful test, current code relies on the existence of the primary keys.
* Add support for foreign keys.