### PR TITLE
Metadata reload and validation

### DIFF
--- a/docs/lua-cpp-reference.md
+++ b/docs/lua-cpp-reference.md
@@ -664,6 +664,42 @@ Currently the DDL configuration can't be modified.
 worker:create_random_tables(5)
 ```
 
+### discover_existing_schema
+
+Discovers and populates the metadata system with the existing database schema.
+
+This function scans the connected database and builds StormWeaver's internal metadata representation based on the actual database structure (tables, columns, indexes, etc.).
+
+```lua
+worker:discover_existing_schema()
+```
+
+### reset_metadata
+
+Clears all metadata, resetting it to an empty state.
+
+This function removes all stored table and schema information from StormWeaver's internal metadata system.
+
+```lua
+worker:reset_metadata()
+```
+
+### validate_metadata
+
+Validates that the current metadata accurately reflects the actual database schema.
+
+This function compares the current metadata against a fresh schema discovery from the database. If validation fails, it writes debug files to the `logs/` directory containing both the original and newly discovered metadata for comparison.
+
+Returns `true` if metadata matches the database schema, `false` otherwise.
+
+```lua
+if worker:validate_metadata() then
+  info("Metadata is consistent with database schema")
+else
+  warning("Metadata validation failed - check logs/ directory for debug files")
+end
+```
+
 ### sql_connection
 
 Returns the SQL connection (LoggedSQL) of the worker, which can be used to execute SQL statements directly.

--- a/libstormweaver/include/metadata.hpp
+++ b/libstormweaver/include/metadata.hpp
@@ -204,7 +204,7 @@ enum class Generated { notGenerated, stored, virt };
 
 struct Column {
   std::string name; // TODO: fixed buffers for strings?
-  ColumnType type;
+  ColumnType type = ColumnType::INT;
 
   std::size_t length = 0;
 
@@ -217,6 +217,10 @@ struct Column {
   bool partition_key = false;
   std::string foreign_key_references;
   bool auto_increment = false;
+
+  auto operator<=>(const Column &other) const = default;
+
+  std::string debug_dump() const;
 };
 
 enum class IndexOrdering { default_, asc, desc };
@@ -224,6 +228,8 @@ enum class IndexOrdering { default_, asc, desc };
 struct IndexColumn {
   std::string column_name; // column + ordering or func(columns...)
   IndexOrdering ordering;
+
+  auto operator<=>(const IndexColumn &other) const = default;
 };
 
 struct Index {
@@ -235,6 +241,11 @@ struct Index {
   boost::container::small_vector<IndexColumn,
                                  limits::optimized_index_column_count>
       fields;
+
+  bool operator==(const Index &other) const;
+  bool operator!=(const Index &other) const;
+
+  std::string debug_dump() const;
 };
 
 struct RangePartition {
@@ -242,11 +253,15 @@ struct RangePartition {
   // TODO: add partition specific indexes?
   // boost::container::small_vector<Index, limits::optimized_index_count>
   // indexes;
+
+  auto operator<=>(const RangePartition &other) const = default;
 };
 
 struct RangePartitioning {
   std::size_t rangeSize;
   std::vector<RangePartition> ranges;
+
+  auto operator<=>(const RangePartitioning &other) const = default;
 };
 
 struct Table {
@@ -267,6 +282,11 @@ struct Table {
   void removeReferencesTo(std::string const &tableName);
   void updateReferencesTo(std::string const &oldTableName,
                           std::string const &newTableName);
+
+  bool operator==(const Table &other) const;
+  bool operator!=(const Table &other) const;
+
+  std::string debug_dump() const;
 };
 
 using table_ptr = std::shared_ptr<Table>;
@@ -320,6 +340,14 @@ public:
   };
 
   Metadata();
+  Metadata(const Metadata &other);
+
+  void reset();
+
+  bool operator==(const Metadata &other) const;
+  bool operator!=(const Metadata &other) const;
+
+  std::string debug_dump() const;
 
   // If no slots are left, returns an invalid (non open) Reservation
   Reservation createTable();

--- a/libstormweaver/include/metadata_populator.hpp
+++ b/libstormweaver/include/metadata_populator.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "metadata.hpp"
+#include "schema_discovery.hpp"
+
+namespace metadata_populator {
+
+class MetadataPopulator {
+public:
+  explicit MetadataPopulator(metadata::Metadata &metadata);
+
+  void
+  populateFromExistingDatabase(schema_discovery::SchemaDiscovery &discovery);
+
+private:
+  metadata::Metadata &metadata_;
+
+  metadata::Table convertCompleteTable(
+      schema_discovery::SchemaDiscovery &discovery,
+      const schema_discovery::DiscoveredTable &discovered_table);
+
+  metadata::Column
+  convertColumn(const schema_discovery::DiscoveredColumn &discovered);
+  metadata::Index
+  convertIndex(const schema_discovery::DiscoveredIndex &discovered);
+
+  void applyConstraints(
+      metadata::Table &table,
+      const std::vector<schema_discovery::DiscoveredConstraint> &constraints);
+
+  void applyPartitionKeys(metadata::Table &table,
+                          const std::vector<std::string> &partition_keys);
+
+  void applyPartitioning(
+      metadata::Table &table,
+      const std::vector<schema_discovery::DiscoveredPartition> &partitions);
+};
+
+} // namespace metadata_populator

--- a/libstormweaver/include/schema_discovery.hpp
+++ b/libstormweaver/include/schema_discovery.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "metadata.hpp"
+#include "sql_variant/generic.hpp"
+
+namespace schema_discovery {
+
+enum class PartitionType { none, range, hash, list };
+
+enum class ConstraintType { primary_key, foreign_key, unique, check, unknown };
+
+struct DiscoveredTable {
+  std::string name;
+  metadata::Table::Type table_type = metadata::Table::Type::normal;
+  std::string access_method; // heap, tde_heap, etc.
+  std::string tablespace;
+  bool is_partition = false;
+  PartitionType partition_type = PartitionType::none;
+};
+
+struct DiscoveredColumn {
+  std::string name;
+  metadata::ColumnType data_type = metadata::ColumnType::TEXT;
+  int length = 0; // For char/varchar types
+  int type_modifier = -1;
+  bool not_null = false;
+  int ordinal_position = 0;
+  bool is_serial = false;
+  metadata::Generated generated_type = metadata::Generated::notGenerated;
+  std::string default_value;
+};
+
+struct DiscoveredIndex {
+  std::string name;
+  bool is_unique = false;
+  std::vector<std::string> column_names;
+  std::vector<metadata::IndexOrdering> orderings;
+};
+
+struct DiscoveredConstraint {
+  std::string name;
+  ConstraintType type = ConstraintType::unknown;
+  std::vector<std::string> columns;
+  std::string referenced_table;                // For foreign key constraints
+  std::vector<std::string> referenced_columns; // For foreign key constraints
+};
+
+struct DiscoveredPartition {
+  std::string name;
+  std::string partition_bound; // Raw PostgreSQL partition bound expression
+};
+
+class SchemaDiscovery {
+public:
+  explicit SchemaDiscovery(sql_variant::LoggedSQL *connection);
+
+  std::vector<DiscoveredTable> discoverTables();
+  std::vector<DiscoveredColumn> discoverColumns(const std::string &table_name);
+  std::vector<DiscoveredIndex> discoverIndexes(const std::string &table_name);
+  std::vector<DiscoveredConstraint>
+  discoverConstraints(const std::string &table_name);
+  std::vector<DiscoveredPartition>
+  discoverPartitions(const std::string &table_name);
+  std::vector<std::string> discoverPartitionKeys(const std::string &table_name);
+
+private:
+  sql_variant::LoggedSQL *connection_;
+
+  std::string parseAccessMethod(const std::string &am_name);
+  std::string parseTablespace(const std::string &ts_name);
+  int parseTypeModifier(const std::string &type_name, int type_modifier);
+
+  metadata::Table::Type parseTableType(const std::string &type_char);
+  PartitionType parsePartitionType(const std::string &partition_type_str);
+  metadata::ColumnType parseDataType(const std::string &type_name);
+  metadata::Generated parseGeneratedType(const std::string &generated_str);
+  metadata::IndexOrdering parseIndexOrdering(const std::string &ordering_str);
+  ConstraintType parseConstraintType(const std::string &type_char);
+};
+
+} // namespace schema_discovery

--- a/libstormweaver/include/workload.hpp
+++ b/libstormweaver/include/workload.hpp
@@ -34,6 +34,12 @@ public:
 
   void create_random_tables(std::size_t count);
 
+  void discover_existing_schema();
+
+  void reset_metadata();
+
+  bool validate_metadata();
+
   sql_variant::LoggedSQL *sql_connection() const;
 
   void reconnect();

--- a/libstormweaver/src/CMakeLists.txt
+++ b/libstormweaver/src/CMakeLists.txt
@@ -12,6 +12,8 @@ set(LIBRARY_SOURCES
     metadata.cpp
     workload.cpp
     scripting/luactx.cpp
+    schema_discovery.cpp
+    metadata_populator.cpp
     sql_variant/generic.cpp
     #sql_variant/mysql.cpp
     sql_variant/postgresql.cpp

--- a/libstormweaver/src/metadata.cpp
+++ b/libstormweaver/src/metadata.cpp
@@ -1,9 +1,49 @@
 
 #include "metadata.hpp"
 
+#include <algorithm>
+#include <fmt/format.h>
 #include <iostream>
 
 namespace metadata {
+
+bool Index::operator==(const Index &other) const {
+  if (name != other.name || unique != other.unique ||
+      fields.size() != other.fields.size()) {
+    return false;
+  }
+
+  return fields == other.fields;
+}
+
+bool Index::operator!=(const Index &other) const { return !(*this == other); }
+
+bool Table::operator==(const Table &other) const {
+  if (name != other.name || engine != other.engine ||
+      tablespace != other.tablespace || partitioning != other.partitioning ||
+      columns.size() != other.columns.size() ||
+      indexes.size() != other.indexes.size()) {
+    return false;
+  }
+
+  for (const auto &column : columns) {
+    if (std::find(other.columns.begin(), other.columns.end(), column) ==
+        other.columns.end()) {
+      return false;
+    }
+  }
+
+  for (const auto &index : indexes) {
+    if (std::find(other.indexes.begin(), other.indexes.end(), index) ==
+        other.indexes.end()) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool Table::operator!=(const Table &other) const { return !(*this == other); }
 
 bool Table::hasReferenceTo(std::string const &tableName) const {
   for (std::size_t idx = 0; idx < columns.size(); ++idx) {
@@ -35,9 +75,7 @@ Metadata::Reservation::Reservation(Metadata *storage, Metadata::table_t table,
                                    bool drop, std::size_t index,
                                    std::unique_lock<std::shared_mutex> &&lock)
     : storage_(storage), table_(table), drop_(drop), index_(index),
-      lock_(std::move(lock)) {
-  //
-}
+      lock_(std::move(lock)) {}
 
 Metadata::Reservation::~Reservation() {
   if (open()) {
@@ -263,6 +301,221 @@ table_cptr Metadata::operator[](Metadata::index_t idx) const {
   // assert: idx < limits::maximum_table_count
   std::shared_lock<std::shared_mutex> mtx(data_.tableLocks[idx]);
   return data_.tables[idx];
+}
+
+Metadata::Metadata(const Metadata &other) {
+  data_.tableCount = other.data_.tableCount.load();
+  data_.reservedSize = other.data_.reservedSize.load();
+
+  for (std::size_t i = 0; i < limits::maximum_table_count; ++i) {
+    if (other.data_.tables[i]) {
+      data_.tables[i] = std::make_shared<Table>(*other.data_.tables[i]);
+    } else {
+      data_.tables[i] = nullptr;
+    }
+    data_.movedToMap[i] = other.data_.movedToMap[i];
+  }
+}
+
+void Metadata::reset() {
+  for (std::size_t i = 0; i < limits::maximum_table_count; ++i) {
+    std::unique_lock<std::shared_mutex> lock(data_.tableLocks[i]);
+    data_.tables[i] = nullptr;
+    data_.movedToMap[i] = npos;
+  }
+
+  data_.tableCount = 0;
+  data_.reservedSize = 0;
+}
+
+bool Metadata::operator==(const Metadata &other) const {
+  if (size() != other.size()) {
+    return false;
+  }
+
+  std::vector<table_cptr> this_tables;
+  for (std::size_t i = 0; i < limits::maximum_table_count; ++i) {
+    auto table = (*this)[i];
+    if (table) {
+      this_tables.push_back(table);
+    }
+  }
+
+  std::vector<table_cptr> other_tables;
+  for (std::size_t i = 0; i < limits::maximum_table_count; ++i) {
+    auto table = other[i];
+    if (table) {
+      other_tables.push_back(table);
+    }
+  }
+
+  auto table_comparator = [](const table_cptr &a, const table_cptr &b) {
+    return a->name < b->name;
+  };
+
+  std::sort(this_tables.begin(), this_tables.end(), table_comparator);
+  std::sort(other_tables.begin(), other_tables.end(), table_comparator);
+
+  for (std::size_t i = 0; i < this_tables.size(); ++i) {
+    if (*this_tables[i] != *other_tables[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool Metadata::operator!=(const Metadata &other) const {
+  return !(*this == other);
+}
+
+std::string Column::debug_dump() const {
+  std::string type_str;
+  switch (type) {
+  case ColumnType::INT:
+    type_str = "INT";
+    break;
+  case ColumnType::CHAR:
+    type_str = "CHAR";
+    break;
+  case ColumnType::VARCHAR:
+    type_str = "VARCHAR";
+    break;
+  case ColumnType::REAL:
+    type_str = "REAL";
+    break;
+  case ColumnType::BOOL:
+    type_str = "BOOL";
+    break;
+  case ColumnType::BYTEA:
+    type_str = "BYTEA";
+    break;
+  case ColumnType::TEXT:
+    type_str = "TEXT";
+    break;
+  }
+
+  if (length > 0) {
+    type_str = fmt::format("{}({})", type_str, length);
+  }
+
+  std::vector<std::string> attributes;
+  if (primary_key)
+    attributes.push_back("PRIMARY KEY");
+  if (auto_increment)
+    attributes.push_back("AUTO_INCREMENT");
+  if (!nullable)
+    attributes.push_back("NOT NULL");
+  if (partition_key)
+    attributes.push_back("PARTITION KEY");
+  if (!foreign_key_references.empty()) {
+    attributes.push_back(fmt::format("REFERENCES {}", foreign_key_references));
+  }
+  if (!default_value.empty()) {
+    attributes.push_back(fmt::format("DEFAULT '{}'", default_value));
+  }
+  if (generated != Generated::notGenerated) {
+    attributes.push_back(fmt::format(
+        "GENERATED {}", generated == Generated::stored ? "STORED" : "VIRTUAL"));
+  }
+
+  std::string result = fmt::format("{} {}", name, type_str);
+  for (const auto &attr : attributes) {
+    result += fmt::format(" {}", attr);
+  }
+  return result;
+}
+
+std::string Index::debug_dump() const {
+  std::vector<std::string> field_strs;
+  for (const auto &field : fields) {
+    std::string field_str = field.column_name;
+    if (field.ordering != IndexOrdering::default_) {
+      field_str =
+          fmt::format("{} {}", field_str,
+                      field.ordering == IndexOrdering::asc ? "ASC" : "DESC");
+    }
+    field_strs.push_back(field_str);
+  }
+
+  std::string fields_str;
+  for (std::size_t i = 0; i < field_strs.size(); ++i) {
+    if (i > 0)
+      fields_str += ", ";
+    fields_str += field_strs[i];
+  }
+
+  return fmt::format("{}{} ({})", name, unique ? " UNIQUE" : "", fields_str);
+}
+
+std::string Table::debug_dump() const {
+  std::vector<std::string> lines;
+
+  lines.push_back(fmt::format("Table: {}", name));
+  lines.push_back(fmt::format("  Engine: {}", engine));
+  if (!tablespace.empty()) {
+    lines.push_back(fmt::format("  Tablespace: {}", tablespace));
+  }
+
+  if (partitioning.has_value()) {
+    lines.push_back(fmt::format("  Partitioning: range (size={}, {} ranges)",
+                                partitioning->rangeSize,
+                                partitioning->ranges.size()));
+    for (const auto &range : partitioning->ranges) {
+      lines.push_back(fmt::format("    Range: base={}", range.rangebase));
+    }
+  }
+
+  lines.push_back(fmt::format("  Columns ({}):", columns.size()));
+  for (const auto &col : columns) {
+    lines.push_back(fmt::format("    {}", col.debug_dump()));
+  }
+
+  if (!indexes.empty()) {
+    lines.push_back(fmt::format("  Indexes ({}):", indexes.size()));
+    for (const auto &idx : indexes) {
+      lines.push_back(fmt::format("    {}", idx.debug_dump()));
+    }
+  }
+
+  std::string result;
+  for (std::size_t i = 0; i < lines.size(); ++i) {
+    if (i > 0)
+      result += "\n";
+    result += lines[i];
+  }
+  return result;
+}
+
+std::string Metadata::debug_dump() const {
+  std::vector<std::string> lines;
+  lines.push_back(fmt::format("Metadata dump (size={}):", size()));
+
+  std::vector<table_cptr> tables;
+  for (std::size_t i = 0; i < limits::maximum_table_count; ++i) {
+    auto table = (*this)[i];
+    if (table) {
+      tables.push_back(table);
+    }
+  }
+
+  auto table_comparator = [](const table_cptr &a, const table_cptr &b) {
+    return a->name < b->name;
+  };
+  std::sort(tables.begin(), tables.end(), table_comparator);
+
+  for (const auto &table : tables) {
+    lines.push_back(table->debug_dump());
+    lines.push_back("");
+  }
+
+  std::string result;
+  for (std::size_t i = 0; i < lines.size(); ++i) {
+    if (i > 0)
+      result += "\n";
+    result += lines[i];
+  }
+  return result;
 }
 
 } // namespace metadata

--- a/libstormweaver/src/metadata_populator.cpp
+++ b/libstormweaver/src/metadata_populator.cpp
@@ -1,0 +1,223 @@
+#include "metadata_populator.hpp"
+
+#include <algorithm>
+#include <spdlog/spdlog.h>
+
+namespace metadata_populator {
+
+MetadataPopulator::MetadataPopulator(metadata::Metadata &metadata)
+    : metadata_(metadata) {}
+
+void MetadataPopulator::populateFromExistingDatabase(
+    schema_discovery::SchemaDiscovery &discovery) {
+  auto tables = discovery.discoverTables();
+
+  spdlog::info("Starting metadata population for {} discovered tables",
+               tables.size());
+
+  for (const auto &discovered_table : tables) {
+    try {
+      metadata::Metadata::Reservation res = metadata_.createTable();
+      if (!res.open()) {
+        spdlog::warn("No more table slots available, skipping table {}",
+                     discovered_table.name);
+        continue;
+      }
+
+      auto table = convertCompleteTable(discovery, discovered_table);
+      *res.table() = table;
+      res.complete();
+
+      spdlog::debug("Successfully populated metadata for table {}",
+                    discovered_table.name);
+
+    } catch (const std::exception &e) {
+      spdlog::error("Failed to populate metadata for table {}: {}",
+                    discovered_table.name, e.what());
+    }
+  }
+
+  spdlog::info("Metadata population completed for {} tables", metadata_.size());
+}
+
+metadata::Table MetadataPopulator::convertCompleteTable(
+    schema_discovery::SchemaDiscovery &discovery,
+    const schema_discovery::DiscoveredTable &discovered_table) {
+  metadata::Table table;
+  table.name = discovered_table.name;
+  table.tablespace = discovered_table.tablespace;
+
+  // TODO: ddl operations do not set the engine field yet
+  // table.engine = discovered_table.access_method;
+
+  if (discovered_table.table_type == metadata::Table::Type::partitioned) {
+    // Partitioned table - we'll set this up below when we discover partitions
+  }
+
+  auto columns = discovery.discoverColumns(discovered_table.name);
+  for (const auto &discovered_col : columns) {
+    table.columns.push_back(convertColumn(discovered_col));
+  }
+
+  auto indexes = discovery.discoverIndexes(discovered_table.name);
+  for (const auto &discovered_idx : indexes) {
+    table.indexes.push_back(convertIndex(discovered_idx));
+  }
+
+  // Apply primary key flags to columns
+  auto constraints = discovery.discoverConstraints(discovered_table.name);
+  applyConstraints(table, constraints);
+
+  // Mark columns as partition keys
+  auto partition_keys = discovery.discoverPartitionKeys(discovered_table.name);
+  applyPartitionKeys(table, partition_keys);
+
+  auto partitions = discovery.discoverPartitions(discovered_table.name);
+  if (!partitions.empty()) {
+    applyPartitioning(table, partitions);
+  }
+
+  spdlog::debug("Converted table {} with {} columns, {} indexes, {} "
+                "constraints, {} partitions",
+                table.name, table.columns.size(), table.indexes.size(),
+                constraints.size(), partitions.size());
+
+  return table;
+}
+
+metadata::Column MetadataPopulator::convertColumn(
+    const schema_discovery::DiscoveredColumn &discovered) {
+  metadata::Column column;
+
+  column.name = discovered.name;
+  column.type = discovered.data_type;
+  column.length = static_cast<std::size_t>(std::max(0, discovered.length));
+  column.nullable = !discovered.not_null;
+  column.auto_increment = discovered.is_serial;
+
+  // Skip default values for auto_increment columns (SERIAL in PostgreSQL)
+  if (!discovered.default_value.empty() && !discovered.is_serial) {
+    column.default_value = discovered.default_value;
+  }
+
+  column.generated = discovered.generated_type;
+
+  return column;
+}
+
+metadata::Index MetadataPopulator::convertIndex(
+    const schema_discovery::DiscoveredIndex &discovered) {
+  metadata::Index index;
+
+  index.name = discovered.name;
+  index.unique = discovered.is_unique;
+
+  for (std::size_t i = 0; i < discovered.column_names.size(); ++i) {
+    metadata::IndexColumn idx_col;
+    idx_col.column_name = discovered.column_names[i];
+
+    if (i < discovered.orderings.size()) {
+      idx_col.ordering = discovered.orderings[i];
+    } else {
+      idx_col.ordering = metadata::IndexOrdering::default_;
+    }
+
+    index.fields.push_back(idx_col);
+  }
+
+  return index;
+}
+
+void MetadataPopulator::applyConstraints(
+    metadata::Table &table,
+    const std::vector<schema_discovery::DiscoveredConstraint> &constraints) {
+  for (const auto &constraint : constraints) {
+    if (constraint.type == schema_discovery::ConstraintType::primary_key) {
+      for (const auto &col_name : constraint.columns) {
+        auto it = std::find_if(table.columns.begin(), table.columns.end(),
+                               [&col_name](const metadata::Column &col) {
+                                 return col.name == col_name;
+                               });
+        if (it != table.columns.end()) {
+          it->primary_key = true;
+          spdlog::debug("Marked column {} as primary key", col_name);
+        }
+      }
+    } else if (constraint.type ==
+               schema_discovery::ConstraintType::foreign_key) {
+      for (const auto &col_name : constraint.columns) {
+        auto it = std::find_if(table.columns.begin(), table.columns.end(),
+                               [&col_name](const metadata::Column &col) {
+                                 return col.name == col_name;
+                               });
+        if (it != table.columns.end()) {
+          it->foreign_key_references = constraint.referenced_table;
+          spdlog::debug("Marked column {} as foreign key referencing {}",
+                        col_name, constraint.referenced_table);
+        }
+      }
+    }
+    // Note: Other constraint types (UNIQUE, CHECK) are not currently
+    // represented in StormWeaver's metadata structure, so we skip them
+  }
+}
+
+void MetadataPopulator::applyPartitionKeys(
+    metadata::Table &table, const std::vector<std::string> &partition_keys) {
+  for (const auto &key_col_name : partition_keys) {
+    auto it = std::find_if(table.columns.begin(), table.columns.end(),
+                           [&key_col_name](const metadata::Column &col) {
+                             return col.name == key_col_name;
+                           });
+    if (it != table.columns.end()) {
+      it->partition_key = true;
+      spdlog::debug("Marked column {} as partition key", key_col_name);
+    } else {
+      spdlog::warn("Partition key column {} not found in table {}",
+                   key_col_name, table.name);
+    }
+  }
+
+  spdlog::debug("Applied {} partition keys to table {}", partition_keys.size(),
+                table.name);
+}
+
+void MetadataPopulator::applyPartitioning(
+    metadata::Table &table,
+    const std::vector<schema_discovery::DiscoveredPartition> &partitions) {
+  if (partitions.empty()) {
+    return;
+  }
+
+  // Currently only supports basic range partitioning
+  table.partitioning = metadata::RangePartitioning{};
+  table.partitioning->rangeSize = 10000000; // Default range size
+
+  for (const auto &partition : partitions) {
+    metadata::RangePartition range_partition{0};
+    // Extract range base from partition name (format: "table_name_p0",
+    // "table_name_p1", etc.)
+    std::size_t pos = partition.name.rfind('_');
+    if (pos != std::string::npos && pos + 1 < partition.name.length()) {
+      try {
+        std::string range_str = partition.name.substr(pos + 1);
+        if (range_str[0] == 'p') {
+          range_partition.rangebase = std::stoull(range_str.substr(1));
+        }
+      } catch (const std::exception &e) {
+        spdlog::warn("Could not parse range base from partition name {}: {}",
+                     partition.name, e.what());
+        range_partition.rangebase = 0;
+      }
+    }
+
+    table.partitioning->ranges.push_back(range_partition);
+    spdlog::debug("Added partition {} with range base {}", partition.name,
+                  range_partition.rangebase);
+  }
+
+  spdlog::debug("Applied partitioning to table {} with {} partitions",
+                table.name, table.partitioning->ranges.size());
+}
+
+} // namespace metadata_populator

--- a/libstormweaver/src/schema_discovery.cpp
+++ b/libstormweaver/src/schema_discovery.cpp
@@ -1,0 +1,498 @@
+#include "schema_discovery.hpp"
+
+#include <fmt/format.h>
+#include <map>
+#include <spdlog/spdlog.h>
+#include <sstream>
+
+namespace schema_discovery {
+
+SchemaDiscovery::SchemaDiscovery(sql_variant::LoggedSQL *connection)
+    : connection_(connection) {
+  if (!connection_) {
+    throw std::invalid_argument("Connection cannot be null");
+  }
+}
+
+std::vector<DiscoveredTable> SchemaDiscovery::discoverTables() {
+  std::vector<DiscoveredTable> tables;
+
+  const std::string query = R"(
+        SELECT 
+          c.relname as table_name,
+          c.relkind as table_type,
+          COALESCE(am.amname, 'heap') as access_method,
+          COALESCE(ts.spcname, 'pg_default') as tablespace,
+          c.relpartbound IS NOT NULL as is_partition,
+          CASE WHEN c.relkind = 'p' THEN 'RANGE' ELSE '' END as partition_type
+        FROM pg_class c
+        LEFT JOIN pg_am am ON c.relam = am.oid
+        LEFT JOIN pg_tablespace ts ON c.reltablespace = ts.oid
+        WHERE c.relkind IN ('r', 'p')
+          AND c.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
+          AND NOT c.relispartition
+        ORDER BY c.relname
+    )";
+
+  try {
+    auto result = connection_->executeQuery(query);
+    result.maybeThrow();
+
+    if (result.data) {
+      for (std::size_t i = 0; i < result.data->numRows(); ++i) {
+        auto row = result.data->nextRow();
+
+        DiscoveredTable table;
+        table.name = std::string(row.rowData[0].value_or(""));
+        table.table_type =
+            parseTableType(std::string(row.rowData[1].value_or("")));
+        table.access_method =
+            parseAccessMethod(std::string(row.rowData[2].value_or("heap")));
+        table.tablespace =
+            parseTablespace(std::string(row.rowData[3].value_or("pg_default")));
+        table.is_partition = (row.rowData[4].value_or("f") == "t");
+        table.partition_type =
+            parsePartitionType(std::string(row.rowData[5].value_or("")));
+
+        tables.push_back(table);
+      }
+    }
+
+    spdlog::debug("Discovered {} tables", tables.size());
+
+  } catch (const std::exception &e) {
+    spdlog::error("Failed to discover tables: {}", e.what());
+    throw;
+  }
+
+  return tables;
+}
+
+std::vector<DiscoveredColumn>
+SchemaDiscovery::discoverColumns(const std::string &table_name) {
+  std::vector<DiscoveredColumn> columns;
+
+  const std::string query = fmt::format(R"(
+        SELECT 
+          a.attname as column_name,
+          t.typname as data_type,
+          a.attlen as length,
+          a.atttypmod as type_modifier,
+          a.attnotnull as not_null,
+          a.attnum as ordinal_position,
+          CASE WHEN pg_get_expr(ad.adbin, ad.adrelid) LIKE 'nextval%' THEN true ELSE false END as is_serial,
+          CASE WHEN a.attgenerated = 's' THEN 'stored'
+               WHEN a.attgenerated = 'v' THEN 'virtual'
+               ELSE 'not_generated' END as generated_type,
+          COALESCE(pg_get_expr(ad.adbin, ad.adrelid), '') as default_value
+        FROM pg_attribute a
+        JOIN pg_type t ON a.atttypid = t.oid
+        LEFT JOIN pg_attrdef ad ON a.attrelid = ad.adrelid AND a.attnum = ad.adnum
+        WHERE a.attrelid = (
+            SELECT c.oid FROM pg_class c 
+            JOIN pg_namespace n ON c.relnamespace = n.oid 
+            WHERE c.relname = '{}' AND n.nspname = 'public'
+        )
+          AND a.attnum > 0
+          AND NOT a.attisdropped
+        ORDER BY a.attnum
+    )",
+                                        table_name);
+
+  try {
+    auto result = connection_->executeQuery(query);
+    result.maybeThrow();
+
+    if (result.data) {
+      for (std::size_t i = 0; i < result.data->numRows(); ++i) {
+        auto row = result.data->nextRow();
+
+        DiscoveredColumn column;
+        column.name = std::string(row.rowData[0].value_or(""));
+        column.data_type =
+            parseDataType(std::string(row.rowData[1].value_or("")));
+        column.type_modifier =
+            row.rowData[3]
+                ? std::stoi(std::string(row.rowData[3].value_or("-1")))
+                : -1;
+        column.not_null = (row.rowData[4].value_or("f") == "t");
+        column.ordinal_position =
+            row.rowData[5]
+                ? std::stoi(std::string(row.rowData[5].value_or("0")))
+                : 0;
+        column.is_serial = (row.rowData[6].value_or("f") == "t");
+        column.generated_type = parseGeneratedType(
+            std::string(row.rowData[7].value_or("not_generated")));
+        column.default_value = std::string(row.rowData[8].value_or(""));
+
+        if (column.data_type == metadata::ColumnType::VARCHAR ||
+            column.data_type == metadata::ColumnType::CHAR) {
+          column.length = parseTypeModifier(
+              std::string(row.rowData[1].value_or("")), column.type_modifier);
+        } else {
+          column.length = 0;
+        }
+
+        columns.push_back(column);
+      }
+    }
+
+    spdlog::debug("Discovered {} columns for table {}", columns.size(),
+                  table_name);
+
+  } catch (const std::exception &e) {
+    spdlog::error("Failed to discover columns for table {}: {}", table_name,
+                  e.what());
+    throw;
+  }
+
+  return columns;
+}
+
+std::vector<DiscoveredIndex>
+SchemaDiscovery::discoverIndexes(const std::string &table_name) {
+  std::vector<DiscoveredIndex> indexes;
+
+  const std::string query = fmt::format(R"(
+        SELECT 
+          i.relname as index_name,
+          ix.indisunique as is_unique,
+          a.attname as column_name,
+          array_position(ix.indkey, a.attnum) as key_position,
+          pg_get_indexdef(ix.indexrelid) as index_def
+        FROM pg_index ix
+        JOIN pg_class i ON ix.indexrelid = i.oid
+        JOIN pg_class t ON ix.indrelid = t.oid
+        JOIN pg_attribute a ON t.oid = a.attrelid AND a.attnum = ANY(ix.indkey)
+        JOIN pg_namespace n ON t.relnamespace = n.oid
+        WHERE t.relname = '{}' 
+          AND n.nspname = 'public'
+          AND NOT ix.indisprimary
+        ORDER BY i.relname, array_position(ix.indkey, a.attnum)
+    )",
+                                        table_name, table_name);
+
+  try {
+    auto result = connection_->executeQuery(query);
+    result.maybeThrow();
+
+    if (result.data) {
+      std::map<std::string, DiscoveredIndex> index_map;
+
+      for (std::size_t i = 0; i < result.data->numRows(); ++i) {
+        auto row = result.data->nextRow();
+
+        std::string index_name = std::string(row.rowData[0].value_or(""));
+        bool is_unique = (row.rowData[1].value_or("f") == "t");
+        std::string column_name = std::string(row.rowData[2].value_or(""));
+        std::string index_def = std::string(row.rowData[4].value_or(""));
+
+        std::string ordering = "asc";
+        std::string search_pattern = column_name + " DESC";
+        if (index_def.find(search_pattern) != std::string::npos) {
+          ordering = "desc";
+        }
+
+        auto it = index_map.find(index_name);
+        if (it == index_map.end()) {
+          DiscoveredIndex new_index;
+          new_index.name = index_name;
+          new_index.is_unique = is_unique;
+          index_map[index_name] = new_index;
+        }
+
+        index_map[index_name].column_names.push_back(column_name);
+        index_map[index_name].orderings.push_back(parseIndexOrdering(ordering));
+      }
+
+      for (const auto &pair : index_map) {
+        indexes.push_back(pair.second);
+      }
+    }
+
+    spdlog::debug("Discovered {} indexes for table {}", indexes.size(),
+                  table_name);
+
+  } catch (const std::exception &e) {
+    spdlog::error("Failed to discover indexes for table {}: {}", table_name,
+                  e.what());
+    throw;
+  }
+
+  return indexes;
+}
+
+std::vector<DiscoveredConstraint>
+SchemaDiscovery::discoverConstraints(const std::string &table_name) {
+  std::vector<DiscoveredConstraint> constraints;
+
+  const std::string query = fmt::format(R"(
+        SELECT 
+          c.conname as constraint_name,
+          c.contype as constraint_type,
+          array_to_string(array(
+            SELECT a.attname
+            FROM pg_attribute a
+            WHERE a.attrelid = c.conrelid 
+              AND a.attnum = ANY(c.conkey)
+            ORDER BY array_position(c.conkey, a.attnum)
+          ), ',') as column_names,
+          COALESCE(
+            CASE 
+              WHEN ft.relispartition = true THEN parent_ft.relname
+              ELSE ft.relname 
+            END, 
+            ''
+          ) as referenced_table,
+          COALESCE(array_to_string(array(
+            SELECT fa.attname
+            FROM pg_attribute fa
+            WHERE fa.attrelid = c.confrelid 
+              AND fa.attnum = ANY(c.confkey)
+            ORDER BY array_position(c.confkey, fa.attnum)
+          ), ','), '') as referenced_columns
+        FROM pg_constraint c
+        JOIN pg_class t ON c.conrelid = t.oid
+        LEFT JOIN pg_class ft ON c.confrelid = ft.oid
+        LEFT JOIN pg_inherits inh ON ft.oid = inh.inhrelid AND ft.relispartition = true
+        LEFT JOIN pg_class parent_ft ON inh.inhparent = parent_ft.oid
+        JOIN pg_namespace n ON t.relnamespace = n.oid
+        WHERE t.relname = '{}' 
+          AND n.nspname = 'public'
+          AND c.contype IN ('p', 'u', 'c', 'f')
+        ORDER BY c.conname
+    )",
+                                        table_name);
+
+  try {
+    auto result = connection_->executeQuery(query);
+    result.maybeThrow();
+
+    if (result.data) {
+      for (std::size_t i = 0; i < result.data->numRows(); ++i) {
+        auto row = result.data->nextRow();
+
+        DiscoveredConstraint constraint;
+        constraint.name = std::string(row.rowData[0].value_or(""));
+        constraint.type =
+            parseConstraintType(std::string(row.rowData[1].value_or("")));
+
+        std::string column_names_str = std::string(row.rowData[2].value_or(""));
+        std::stringstream ss(column_names_str);
+        std::string item;
+
+        while (std::getline(ss, item, ',')) {
+          if (!item.empty()) {
+            constraint.columns.push_back(item);
+          }
+        }
+
+        constraint.referenced_table = std::string(row.rowData[3].value_or(""));
+        std::string referenced_columns_str =
+            std::string(row.rowData[4].value_or(""));
+        if (!referenced_columns_str.empty()) {
+          std::stringstream ref_ss(referenced_columns_str);
+          std::string ref_item;
+
+          while (std::getline(ref_ss, ref_item, ',')) {
+            if (!ref_item.empty()) {
+              constraint.referenced_columns.push_back(ref_item);
+            }
+          }
+        }
+
+        constraints.push_back(constraint);
+      }
+    }
+
+    spdlog::debug("Discovered {} constraints for table {}", constraints.size(),
+                  table_name);
+
+  } catch (const std::exception &e) {
+    spdlog::error("Failed to discover constraints for table {}: {}", table_name,
+                  e.what());
+    throw;
+  }
+
+  return constraints;
+}
+
+std::vector<DiscoveredPartition>
+SchemaDiscovery::discoverPartitions(const std::string &table_name) {
+  std::vector<DiscoveredPartition> partitions;
+
+  const std::string query = fmt::format(R"(
+        SELECT 
+          child.relname as partition_name,
+          pg_get_expr(child.relpartbound, child.oid) as partition_bound
+        FROM pg_class parent
+        JOIN pg_namespace parent_ns ON parent.relnamespace = parent_ns.oid
+        JOIN pg_inherits inh ON parent.oid = inh.inhparent
+        JOIN pg_class child ON inh.inhrelid = child.oid
+        JOIN pg_namespace child_ns ON child.relnamespace = child_ns.oid
+        WHERE parent.relname = '{}'
+          AND parent_ns.nspname = 'public'
+          AND child_ns.nspname = 'public'
+          AND child.relispartition = true
+        ORDER BY child.relname
+    )",
+                                        table_name);
+
+  try {
+    auto result = connection_->executeQuery(query);
+    result.maybeThrow();
+
+    if (result.data) {
+      for (std::size_t i = 0; i < result.data->numRows(); ++i) {
+        auto row = result.data->nextRow();
+
+        DiscoveredPartition partition;
+        partition.name = std::string(row.rowData[0].value_or(""));
+        partition.partition_bound = std::string(row.rowData[1].value_or(""));
+
+        partitions.push_back(partition);
+      }
+    }
+
+    spdlog::debug("Discovered {} partitions for table {}", partitions.size(),
+                  table_name);
+
+  } catch (const std::exception &e) {
+    spdlog::error("Failed to discover partitions for table {}: {}", table_name,
+                  e.what());
+    throw;
+  }
+
+  return partitions;
+}
+
+std::vector<std::string>
+SchemaDiscovery::discoverPartitionKeys(const std::string &table_name) {
+  std::vector<std::string> partition_keys;
+
+  const std::string query = fmt::format(R"(
+        SELECT a.attname as column_name
+        FROM pg_class c
+        JOIN pg_namespace n ON c.relnamespace = n.oid
+        JOIN pg_partitioned_table pt ON c.oid = pt.partrelid
+        JOIN pg_attribute a ON c.oid = a.attrelid
+        WHERE c.relname = '{}'
+          AND n.nspname = 'public'
+          AND a.attnum = ANY(pt.partattrs)
+        ORDER BY array_position(pt.partattrs, a.attnum)
+    )",
+                                        table_name);
+
+  try {
+    auto result = connection_->executeQuery(query);
+    result.maybeThrow();
+
+    if (result.data) {
+      for (std::size_t i = 0; i < result.data->numRows(); ++i) {
+        auto row = result.data->nextRow();
+
+        std::string column_name = std::string(row.rowData[0].value_or(""));
+        if (!column_name.empty()) {
+          partition_keys.push_back(column_name);
+        }
+      }
+    }
+
+    spdlog::debug("Discovered {} partition key columns for table {}",
+                  partition_keys.size(), table_name);
+
+  } catch (const std::exception &e) {
+    spdlog::error("Failed to discover partition keys for table {}: {}",
+                  table_name, e.what());
+    throw;
+  }
+
+  return partition_keys;
+}
+
+std::string SchemaDiscovery::parseAccessMethod(const std::string &am_name) {
+  return am_name;
+}
+
+std::string SchemaDiscovery::parseTablespace(const std::string &ts_name) {
+  return (ts_name == "pg_default") ? "" : ts_name;
+}
+
+int SchemaDiscovery::parseTypeModifier(const std::string &type_name,
+                                       int type_modifier) {
+  if ((type_name == "varchar" || type_name == "bpchar") && type_modifier >= 4) {
+    return type_modifier - 4; // PostgreSQL stores length + 4 in type modifier
+  }
+  return 0;
+}
+
+metadata::Table::Type
+SchemaDiscovery::parseTableType(const std::string &type_char) {
+  if (type_char == "r")
+    return metadata::Table::Type::normal;
+  if (type_char == "p")
+    return metadata::Table::Type::partitioned;
+  return metadata::Table::Type::normal;
+}
+
+PartitionType
+SchemaDiscovery::parsePartitionType(const std::string &partition_type_str) {
+  if (partition_type_str == "RANGE")
+    return PartitionType::range;
+  if (partition_type_str == "HASH")
+    return PartitionType::hash;
+  if (partition_type_str == "LIST")
+    return PartitionType::list;
+  return PartitionType::none;
+}
+
+metadata::ColumnType
+SchemaDiscovery::parseDataType(const std::string &type_name) {
+  if (type_name == "int2" || type_name == "int4" || type_name == "int8")
+    return metadata::ColumnType::INT;
+  if (type_name == "varchar")
+    return metadata::ColumnType::VARCHAR;
+  if (type_name == "bpchar")
+    return metadata::ColumnType::CHAR;
+  if (type_name == "text")
+    return metadata::ColumnType::TEXT;
+  if (type_name == "float4" || type_name == "float8")
+    return metadata::ColumnType::REAL;
+  if (type_name == "bool")
+    return metadata::ColumnType::BOOL;
+  if (type_name == "bytea")
+    return metadata::ColumnType::BYTEA;
+  // For timestamp, date, and unknown types, map to TEXT as fallback
+  return metadata::ColumnType::TEXT;
+}
+
+metadata::Generated
+SchemaDiscovery::parseGeneratedType(const std::string &generated_str) {
+  if (generated_str == "stored")
+    return metadata::Generated::stored;
+  if (generated_str == "virtual")
+    return metadata::Generated::virt;
+  return metadata::Generated::notGenerated;
+}
+
+metadata::IndexOrdering
+SchemaDiscovery::parseIndexOrdering(const std::string &ordering_str) {
+  if (ordering_str == "desc")
+    return metadata::IndexOrdering::desc;
+  return metadata::IndexOrdering::asc;
+}
+
+ConstraintType
+SchemaDiscovery::parseConstraintType(const std::string &type_char) {
+  if (type_char == "p")
+    return ConstraintType::primary_key;
+  if (type_char == "f")
+    return ConstraintType::foreign_key;
+  if (type_char == "u")
+    return ConstraintType::unique;
+  if (type_char == "c")
+    return ConstraintType::check;
+  return ConstraintType::unknown;
+}
+
+} // namespace schema_discovery

--- a/libstormweaver/src/scripting/luactx.cpp
+++ b/libstormweaver/src/scripting/luactx.cpp
@@ -123,6 +123,10 @@ LuaContext::LuaContext(std::shared_ptr<spdlog::logger> logger)
   auto worker_usertype =
       luaState.new_usertype<Worker>("Worker", sol::no_constructor);
   worker_usertype["create_random_tables"] = &Worker::create_random_tables;
+  worker_usertype["discover_existing_schema"] =
+      &Worker::discover_existing_schema;
+  worker_usertype["reset_metadata"] = &Worker::reset_metadata;
+  worker_usertype["validate_metadata"] = &Worker::validate_metadata;
   worker_usertype["sql_connection"] = &Worker::sql_connection;
 
   luaState.new_usertype<RandomWorker>(

--- a/libstormweaver/test/sql/CMakeLists.txt
+++ b/libstormweaver/test/sql/CMakeLists.txt
@@ -1,6 +1,9 @@
 SET(SQLTEST_SOURCES
     main.cpp
     ddl.cpp
+    schema_discovery.cpp
+    metadata_populator.cpp
+    worker_schema_discovery.cpp
 )
 
 add_executable(test-stormweaver-sql ${SQLTEST_SOURCES})

--- a/libstormweaver/test/sql/metadata_populator.cpp
+++ b/libstormweaver/test/sql/metadata_populator.cpp
@@ -1,0 +1,463 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include "metadata_populator.hpp"
+#include "schema_discovery.hpp"
+#include "sql.hpp"
+
+using namespace metadata_populator;
+using namespace schema_discovery;
+
+// Fixture to ensure clean database state for each test
+class MetadataPopulatorFixture {
+public:
+  MetadataPopulatorFixture() {
+    // Recreate public schema to ensure clean state
+    sqlConnection->executeQuery("DROP SCHEMA IF EXISTS public CASCADE")
+        .maybeThrow();
+    sqlConnection->executeQuery("CREATE SCHEMA public").maybeThrow();
+    sqlConnection->executeQuery("GRANT ALL ON SCHEMA public TO public")
+        .maybeThrow();
+  }
+};
+
+TEST_CASE_METHOD(MetadataPopulatorFixture,
+                 "MetadataPopulator - Basic table conversion",
+                 "[metadata_populator]") {
+  REQUIRE(sqlConnection != nullptr);
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE test_populator_basic (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR(100) NOT NULL,
+            price REAL,
+            active BOOLEAN DEFAULT TRUE
+        )
+    )")
+      .maybeThrow();
+
+  metadata::Metadata metadata;
+  SchemaDiscovery discovery(sqlConnection.get());
+  MetadataPopulator populator(metadata);
+
+  populator.populateFromExistingDatabase(discovery);
+
+  REQUIRE(metadata.size() == 1);
+
+  auto table = metadata[0];
+  REQUIRE(table != nullptr);
+  REQUIRE(table->name == "test_populator_basic");
+  REQUIRE(table->engine == "");
+  REQUIRE(table->columns.size() == 4);
+
+  auto find_column =
+      [&table](const std::string &name) -> const metadata::Column * {
+    auto it = std::find_if(
+        table->columns.begin(), table->columns.end(),
+        [&name](const metadata::Column &col) { return col.name == name; });
+    return it != table->columns.end() ? &(*it) : nullptr;
+  };
+
+  auto id_col = find_column("id");
+  REQUIRE(id_col != nullptr);
+  REQUIRE(id_col->type == metadata::ColumnType::INT);
+  REQUIRE(id_col->auto_increment == true);
+  REQUIRE(id_col->primary_key == true);
+  REQUIRE(id_col->nullable == false);
+  // SERIAL columns should have empty default values (not the complex nextval
+  // expression)
+  REQUIRE(id_col->default_value.empty());
+
+  auto name_col = find_column("name");
+  REQUIRE(name_col != nullptr);
+  REQUIRE(name_col->type == metadata::ColumnType::VARCHAR);
+  REQUIRE(name_col->length == 100);
+  REQUIRE(name_col->nullable == false);
+
+  auto price_col = find_column("price");
+  REQUIRE(price_col != nullptr);
+  REQUIRE(price_col->type == metadata::ColumnType::REAL);
+  REQUIRE(price_col->nullable == true);
+
+  auto active_col = find_column("active");
+  REQUIRE(active_col != nullptr);
+  REQUIRE(active_col->type == metadata::ColumnType::BOOL);
+  REQUIRE(active_col->nullable == true);
+  REQUIRE_FALSE(active_col->default_value.empty());
+}
+
+TEST_CASE_METHOD(MetadataPopulatorFixture,
+                 "MetadataPopulator - Index conversion",
+                 "[metadata_populator]") {
+  REQUIRE(sqlConnection != nullptr);
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE test_populator_indexes (
+            id SERIAL PRIMARY KEY,
+            email VARCHAR(255) UNIQUE,
+            name VARCHAR(100),
+            age INT
+        )
+    )")
+      .maybeThrow();
+
+  sqlConnection
+      ->executeQuery("CREATE INDEX idx_name ON test_populator_indexes (name)")
+      .maybeThrow();
+  sqlConnection
+      ->executeQuery("CREATE INDEX idx_name_age ON test_populator_indexes "
+                     "(name, age DESC)")
+      .maybeThrow();
+
+  metadata::Metadata metadata;
+  SchemaDiscovery discovery(sqlConnection.get());
+  MetadataPopulator populator(metadata);
+
+  populator.populateFromExistingDatabase(discovery);
+
+  REQUIRE(metadata.size() == 1);
+
+  auto table = metadata[0];
+  REQUIRE(table != nullptr);
+  REQUIRE(table->indexes.size() == 3); // unique constraint + 2 explicit indexes
+
+  auto find_index =
+      [&table](const std::string &name) -> const metadata::Index * {
+    auto it = std::find_if(
+        table->indexes.begin(), table->indexes.end(),
+        [&name](const metadata::Index &idx) { return idx.name == name; });
+    return it != table->indexes.end() ? &(*it) : nullptr;
+  };
+
+  auto unique_idx = find_index("test_populator_indexes_email_key");
+  REQUIRE(unique_idx != nullptr);
+  REQUIRE(unique_idx->unique == true);
+  REQUIRE(unique_idx->fields.size() == 1);
+  REQUIRE(unique_idx->fields[0].column_name == "email");
+
+  auto name_idx = find_index("idx_name");
+  REQUIRE(name_idx != nullptr);
+  REQUIRE(name_idx->unique == false);
+  REQUIRE(name_idx->fields.size() == 1);
+  REQUIRE(name_idx->fields[0].column_name == "name");
+
+  auto composite_idx = find_index("idx_name_age");
+  REQUIRE(composite_idx != nullptr);
+  REQUIRE(composite_idx->fields.size() == 2);
+  REQUIRE(composite_idx->fields[0].column_name == "name");
+  REQUIRE(composite_idx->fields[1].column_name == "age");
+  REQUIRE(composite_idx->fields[0].ordering == metadata::IndexOrdering::asc);
+  REQUIRE(composite_idx->fields[1].ordering == metadata::IndexOrdering::desc);
+}
+
+TEST_CASE_METHOD(MetadataPopulatorFixture, "MetadataPopulator - Type mapping",
+                 "[metadata_populator]") {
+  REQUIRE(sqlConnection != nullptr);
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE test_populator_types (
+            int_col INT,
+            bigint_col BIGINT,
+            varchar_col VARCHAR(50),
+            char_col CHAR(10),
+            text_col TEXT,
+            real_col REAL,
+            double_col DOUBLE PRECISION,
+            bool_col BOOLEAN,
+            bytea_col BYTEA
+        )
+    )")
+      .maybeThrow();
+
+  metadata::Metadata metadata;
+  SchemaDiscovery discovery(sqlConnection.get());
+  MetadataPopulator populator(metadata);
+
+  populator.populateFromExistingDatabase(discovery);
+
+  REQUIRE(metadata.size() == 1);
+
+  auto table = metadata[0];
+  REQUIRE(table != nullptr);
+  REQUIRE(table->columns.size() == 9);
+
+  auto find_column =
+      [&table](const std::string &name) -> const metadata::Column * {
+    auto it = std::find_if(
+        table->columns.begin(), table->columns.end(),
+        [&name](const metadata::Column &col) { return col.name == name; });
+    return it != table->columns.end() ? &(*it) : nullptr;
+  };
+
+  REQUIRE(find_column("int_col")->type == metadata::ColumnType::INT);
+  REQUIRE(find_column("bigint_col")->type == metadata::ColumnType::INT);
+  REQUIRE(find_column("varchar_col")->type == metadata::ColumnType::VARCHAR);
+  REQUIRE(find_column("char_col")->type == metadata::ColumnType::CHAR);
+  REQUIRE(find_column("text_col")->type == metadata::ColumnType::TEXT);
+  REQUIRE(find_column("real_col")->type == metadata::ColumnType::REAL);
+  REQUIRE(find_column("double_col")->type == metadata::ColumnType::REAL);
+  REQUIRE(find_column("bool_col")->type == metadata::ColumnType::BOOL);
+  REQUIRE(find_column("bytea_col")->type == metadata::ColumnType::BYTEA);
+
+  REQUIRE(find_column("varchar_col")->length == 50);
+  REQUIRE(find_column("char_col")->length == 10);
+}
+
+TEST_CASE_METHOD(MetadataPopulatorFixture,
+                 "MetadataPopulator - Partitioned table conversion",
+                 "[metadata_populator]") {
+  REQUIRE(sqlConnection != nullptr);
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE test_populator_partitioned (
+            id SERIAL,
+            partition_key INT,
+            data TEXT
+        ) PARTITION BY RANGE (partition_key)
+    )")
+      .maybeThrow();
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE test_populator_partitioned_p0 PARTITION OF test_populator_partitioned 
+        FOR VALUES FROM (0) TO (1000)
+    )")
+      .maybeThrow();
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE test_populator_partitioned_p1 PARTITION OF test_populator_partitioned 
+        FOR VALUES FROM (1000) TO (2000)
+    )")
+      .maybeThrow();
+
+  metadata::Metadata metadata;
+  SchemaDiscovery discovery(sqlConnection.get());
+  MetadataPopulator populator(metadata);
+
+  populator.populateFromExistingDatabase(discovery);
+
+  REQUIRE(metadata.size() == 1);
+
+  auto table = metadata[0];
+  REQUIRE(table != nullptr);
+  REQUIRE(table->name == "test_populator_partitioned");
+
+  REQUIRE(table->partitioning.has_value());
+  REQUIRE(table->partitioning->ranges.size() == 2);
+
+  // Verify partition range bases were parsed correctly
+  bool found_p0 = false, found_p1 = false;
+  for (const auto &range : table->partitioning->ranges) {
+    if (range.rangebase == 0)
+      found_p0 = true;
+    if (range.rangebase == 1)
+      found_p1 = true;
+  }
+  REQUIRE(found_p0);
+  REQUIRE(found_p1);
+
+  auto find_column =
+      [&table](const std::string &name) -> const metadata::Column * {
+    auto it = std::find_if(
+        table->columns.begin(), table->columns.end(),
+        [&name](const metadata::Column &col) { return col.name == name; });
+    return it != table->columns.end() ? &(*it) : nullptr;
+  };
+
+  auto partition_key_col = find_column("partition_key");
+  REQUIRE(partition_key_col != nullptr);
+  REQUIRE(partition_key_col->partition_key == true);
+
+  auto id_col = find_column("id");
+  REQUIRE(id_col != nullptr);
+  REQUIRE(id_col->partition_key == false);
+
+  auto data_col = find_column("data");
+  REQUIRE(data_col != nullptr);
+  REQUIRE(data_col->partition_key == false);
+}
+
+TEST_CASE_METHOD(MetadataPopulatorFixture,
+                 "MetadataPopulator - Multiple tables",
+                 "[metadata_populator]") {
+  REQUIRE(sqlConnection != nullptr);
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE test_multi_1 (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR(50)
+        )
+    )")
+      .maybeThrow();
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE test_multi_2 (
+            id SERIAL PRIMARY KEY,
+            description TEXT,
+            price REAL
+        )
+    )")
+      .maybeThrow();
+
+  metadata::Metadata metadata;
+  SchemaDiscovery discovery(sqlConnection.get());
+  MetadataPopulator populator(metadata);
+
+  populator.populateFromExistingDatabase(discovery);
+
+  REQUIRE(metadata.size() == 2);
+  bool found_table1 = false, found_table2 = false;
+  for (std::size_t i = 0; i < metadata.size(); ++i) {
+    auto table = metadata[i];
+    if (table && table->name == "test_multi_1") {
+      found_table1 = true;
+      REQUIRE(table->columns.size() == 2);
+    } else if (table && table->name == "test_multi_2") {
+      found_table2 = true;
+      REQUIRE(table->columns.size() == 3);
+    }
+  }
+
+  REQUIRE(found_table1);
+  REQUIRE(found_table2);
+}
+
+TEST_CASE_METHOD(MetadataPopulatorFixture,
+                 "MetadataPopulator - Foreign key population",
+                 "[metadata_populator]") {
+  REQUIRE(sqlConnection != nullptr);
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE orders (
+            id SERIAL PRIMARY KEY,
+            customer_name VARCHAR(100) NOT NULL,
+            total REAL
+        )
+    )")
+      .maybeThrow();
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE order_items (
+            id SERIAL PRIMARY KEY,
+            order_id INT NOT NULL,
+            product_name VARCHAR(200),
+            quantity INT DEFAULT 1,
+            FOREIGN KEY (order_id) REFERENCES orders(id)
+        )
+    )")
+      .maybeThrow();
+
+  metadata::Metadata metadata;
+  MetadataPopulator populator(metadata);
+  SchemaDiscovery discovery(sqlConnection.get());
+
+  populator.populateFromExistingDatabase(discovery);
+
+  REQUIRE(metadata.size() == 2);
+  const metadata::Table *order_items_table = nullptr;
+  for (std::size_t i = 0; i < metadata.size(); ++i) {
+    auto table = metadata[i];
+    if (table && table->name == "order_items") {
+      order_items_table = table.get();
+      break;
+    }
+  }
+
+  REQUIRE(order_items_table != nullptr);
+  REQUIRE(order_items_table->columns.size() == 4);
+
+  auto order_id_col = std::find_if(
+      order_items_table->columns.begin(), order_items_table->columns.end(),
+      [](const metadata::Column &col) { return col.name == "order_id"; });
+  REQUIRE(order_id_col != order_items_table->columns.end());
+  REQUIRE(order_id_col->foreign_key_references == "orders");
+  REQUIRE_FALSE(order_id_col->nullable); // NOT NULL
+  REQUIRE(order_id_col->type == metadata::ColumnType::INT);
+  auto id_col = std::find_if(
+      order_items_table->columns.begin(), order_items_table->columns.end(),
+      [](const metadata::Column &col) { return col.name == "id"; });
+  REQUIRE(id_col != order_items_table->columns.end());
+  REQUIRE(id_col->foreign_key_references.empty());
+  REQUIRE(id_col->primary_key == true);
+}
+
+TEST_CASE_METHOD(MetadataPopulatorFixture,
+                 "MetadataPopulator - Foreign key to partitioned table",
+                 "[metadata_populator]") {
+  REQUIRE(sqlConnection != nullptr);
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE partitioned_orders (
+            id INT PRIMARY KEY,
+            customer_id INT
+        ) PARTITION BY RANGE (id)
+    )")
+      .maybeThrow();
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE partitioned_orders_2023 PARTITION OF partitioned_orders 
+        FOR VALUES FROM (1000) TO (2000)
+    )")
+      .maybeThrow();
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE order_details (
+            id SERIAL PRIMARY KEY,
+            order_id INT REFERENCES partitioned_orders(id),
+            product_name VARCHAR(100)
+        )
+    )")
+      .maybeThrow();
+
+  metadata::Metadata metadata;
+  SchemaDiscovery discovery(sqlConnection.get());
+  MetadataPopulator populator(metadata);
+
+  populator.populateFromExistingDatabase(discovery);
+
+  REQUIRE(metadata.size() == 2);
+  const metadata::Table *order_details_table = nullptr;
+  for (std::size_t i = 0; i < metadata.size(); ++i) {
+    auto table = metadata[i];
+    if (table && table->name == "order_details") {
+      order_details_table = table.get();
+      break;
+    }
+  }
+
+  REQUIRE(order_details_table != nullptr);
+
+  auto order_id_col = std::find_if(
+      order_details_table->columns.begin(), order_details_table->columns.end(),
+      [](const metadata::Column &col) { return col.name == "order_id"; });
+  REQUIRE(order_id_col != order_details_table->columns.end());
+
+  // Foreign key should reference the parent table, not the partition
+  REQUIRE(order_id_col->foreign_key_references == "partitioned_orders");
+  REQUIRE(order_id_col->foreign_key_references != "partitioned_orders_2023");
+}
+
+TEST_CASE_METHOD(MetadataPopulatorFixture, "MetadataPopulator - Empty database",
+                 "[metadata_populator]") {
+  REQUIRE(sqlConnection != nullptr);
+
+  metadata::Metadata metadata;
+  SchemaDiscovery discovery(sqlConnection.get());
+  MetadataPopulator populator(metadata);
+
+  populator.populateFromExistingDatabase(discovery);
+
+  REQUIRE(metadata.size() == 0);
+}

--- a/libstormweaver/test/sql/schema_discovery.cpp
+++ b/libstormweaver/test/sql/schema_discovery.cpp
@@ -1,0 +1,399 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include "schema_discovery.hpp"
+#include "sql.hpp"
+
+using namespace schema_discovery;
+
+// Fixture to ensure clean database state for each test
+class SchemaDiscoveryFixture {
+public:
+  SchemaDiscoveryFixture() {
+    // Recreate public schema to ensure clean state
+    sqlConnection->executeQuery("DROP SCHEMA IF EXISTS public CASCADE")
+        .maybeThrow();
+    sqlConnection->executeQuery("CREATE SCHEMA public").maybeThrow();
+    sqlConnection->executeQuery("GRANT ALL ON SCHEMA public TO public")
+        .maybeThrow();
+  }
+};
+
+TEST_CASE_METHOD(SchemaDiscoveryFixture,
+                 "SchemaDiscovery - Basic table discovery",
+                 "[schema_discovery]") {
+  REQUIRE(sqlConnection != nullptr);
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE test_basic_table (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR(50) NOT NULL,
+            age INT,
+            active BOOLEAN DEFAULT TRUE
+        )
+    )")
+      .maybeThrow();
+
+  SchemaDiscovery discovery(sqlConnection.get());
+  auto tables = discovery.discoverTables();
+
+  bool found_test_table = false;
+  for (const auto &table : tables) {
+    if (table.name == "test_basic_table") {
+      found_test_table = true;
+      REQUIRE(table.table_type == metadata::Table::Type::normal);
+      REQUIRE(table.access_method == "heap");
+      REQUIRE_FALSE(table.is_partition);
+      break;
+    }
+  }
+
+  REQUIRE(found_test_table);
+}
+
+TEST_CASE_METHOD(SchemaDiscoveryFixture, "SchemaDiscovery - Column discovery",
+                 "[schema_discovery]") {
+  REQUIRE(sqlConnection != nullptr);
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE test_columns (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR(100) NOT NULL,
+            description TEXT,
+            price REAL,
+            active BOOLEAN DEFAULT TRUE,
+            data BYTEA,
+            fixed_char CHAR(10)
+        )
+    )")
+      .maybeThrow();
+
+  SchemaDiscovery discovery(sqlConnection.get());
+  auto columns = discovery.discoverColumns("test_columns");
+
+  REQUIRE(columns.size() == 7);
+
+  auto find_column =
+      [&columns](const std::string &name) -> const DiscoveredColumn * {
+    auto it = std::find_if(
+        columns.begin(), columns.end(),
+        [&name](const DiscoveredColumn &col) { return col.name == name; });
+    return it != columns.end() ? &(*it) : nullptr;
+  };
+
+  auto id_col = find_column("id");
+  REQUIRE(id_col != nullptr);
+  REQUIRE(id_col->data_type == metadata::ColumnType::INT);
+  REQUIRE(id_col->is_serial == true);
+  REQUIRE(id_col->not_null == true);
+
+  auto name_col = find_column("name");
+  REQUIRE(name_col != nullptr);
+  REQUIRE(name_col->data_type == metadata::ColumnType::VARCHAR);
+  REQUIRE(name_col->length == 100);
+  REQUIRE(name_col->not_null == true);
+
+  auto desc_col = find_column("description");
+  REQUIRE(desc_col != nullptr);
+  REQUIRE(desc_col->data_type == metadata::ColumnType::TEXT);
+  REQUIRE(desc_col->not_null == false);
+
+  auto price_col = find_column("price");
+  REQUIRE(price_col != nullptr);
+  REQUIRE(price_col->data_type == metadata::ColumnType::REAL);
+
+  auto active_col = find_column("active");
+  REQUIRE(active_col != nullptr);
+  REQUIRE(active_col->data_type == metadata::ColumnType::BOOL);
+  REQUIRE_THAT(active_col->default_value,
+               Catch::Matchers::ContainsSubstring("true"));
+
+  auto data_col = find_column("data");
+  REQUIRE(data_col != nullptr);
+  REQUIRE(data_col->data_type == metadata::ColumnType::BYTEA);
+
+  auto char_col = find_column("fixed_char");
+  REQUIRE(char_col != nullptr);
+  REQUIRE(char_col->data_type == metadata::ColumnType::CHAR);
+  REQUIRE(char_col->length == 10);
+}
+
+TEST_CASE_METHOD(SchemaDiscoveryFixture, "SchemaDiscovery - Index discovery",
+                 "[schema_discovery]") {
+  REQUIRE(sqlConnection != nullptr);
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE test_indexes (
+            id SERIAL PRIMARY KEY,
+            email VARCHAR(255) UNIQUE,
+            name VARCHAR(100),
+            age INT
+        )
+    )")
+      .maybeThrow();
+
+  sqlConnection->executeQuery("CREATE INDEX idx_name ON test_indexes (name)")
+      .maybeThrow();
+  sqlConnection
+      ->executeQuery(
+          "CREATE INDEX idx_name_age_desc ON test_indexes (name, age DESC)")
+      .maybeThrow();
+
+  SchemaDiscovery discovery(sqlConnection.get());
+  auto indexes = discovery.discoverIndexes("test_indexes");
+
+  // Should have 3 indexes (unique constraint creates an index, plus our 2)
+  REQUIRE(indexes.size() == 3);
+
+  auto find_index =
+      [&indexes](const std::string &name) -> const DiscoveredIndex * {
+    auto it = std::find_if(
+        indexes.begin(), indexes.end(),
+        [&name](const DiscoveredIndex &idx) { return idx.name == name; });
+    return it != indexes.end() ? &(*it) : nullptr;
+  };
+
+  auto unique_idx = find_index("test_indexes_email_key");
+  REQUIRE(unique_idx != nullptr);
+  REQUIRE(unique_idx->is_unique == true);
+  REQUIRE(unique_idx->column_names.size() == 1);
+  REQUIRE(unique_idx->column_names[0] == "email");
+
+  auto name_idx = find_index("idx_name");
+  REQUIRE(name_idx != nullptr);
+  REQUIRE(name_idx->is_unique == false);
+  REQUIRE(name_idx->column_names.size() == 1);
+  REQUIRE(name_idx->column_names[0] == "name");
+
+  auto composite_idx = find_index("idx_name_age_desc");
+  REQUIRE(composite_idx != nullptr);
+  REQUIRE(composite_idx->column_names.size() == 2);
+  REQUIRE(composite_idx->column_names[0] == "name");
+  REQUIRE(composite_idx->column_names[1] == "age");
+  REQUIRE(composite_idx->orderings.size() == 2);
+  REQUIRE(composite_idx->orderings[0] == metadata::IndexOrdering::asc);
+  REQUIRE(composite_idx->orderings[1] == metadata::IndexOrdering::desc);
+}
+
+TEST_CASE_METHOD(SchemaDiscoveryFixture,
+                 "SchemaDiscovery - Constraint discovery",
+                 "[schema_discovery]") {
+  REQUIRE(sqlConnection != nullptr);
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE test_constraints (
+            id SERIAL PRIMARY KEY,
+            email VARCHAR(255) UNIQUE,
+            age INT CHECK (age >= 0 AND age <= 150),
+            status VARCHAR(20) CHECK (status IN ('active', 'inactive'))
+        )
+    )")
+      .maybeThrow();
+
+  SchemaDiscovery discovery(sqlConnection.get());
+  auto constraints = discovery.discoverConstraints("test_constraints");
+
+  // Should have primary key, unique, and check constraints
+  REQUIRE(constraints.size() >= 3);
+
+  auto find_constraint = [&constraints](schema_discovery::ConstraintType type)
+      -> const DiscoveredConstraint * {
+    auto it = std::find_if(
+        constraints.begin(), constraints.end(),
+        [&type](const DiscoveredConstraint &c) { return c.type == type; });
+    return it != constraints.end() ? &(*it) : nullptr;
+  };
+
+  auto pk_constraint =
+      find_constraint(schema_discovery::ConstraintType::primary_key);
+  REQUIRE(pk_constraint != nullptr);
+  REQUIRE(pk_constraint->columns.size() == 1);
+  REQUIRE(pk_constraint->columns[0] == "id");
+
+  auto unique_constraint =
+      find_constraint(schema_discovery::ConstraintType::unique);
+  REQUIRE(unique_constraint != nullptr);
+  REQUIRE(unique_constraint->columns.size() == 1);
+  REQUIRE(unique_constraint->columns[0] == "email");
+
+  auto check_constraints =
+      std::count_if(constraints.begin(), constraints.end(),
+                    [](const DiscoveredConstraint &c) {
+                      return c.type == schema_discovery::ConstraintType::check;
+                    });
+  REQUIRE(check_constraints >= 2);
+}
+
+TEST_CASE_METHOD(SchemaDiscoveryFixture,
+                 "SchemaDiscovery - Partitioned table discovery",
+                 "[schema_discovery]") {
+  REQUIRE(sqlConnection != nullptr);
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE test_partitioned (
+            id SERIAL,
+            partition_key INT,
+            data TEXT
+        ) PARTITION BY RANGE (partition_key)
+    )")
+      .maybeThrow();
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE test_partitioned_p0 PARTITION OF test_partitioned 
+        FOR VALUES FROM (0) TO (1000)
+    )")
+      .maybeThrow();
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE test_partitioned_p1 PARTITION OF test_partitioned 
+        FOR VALUES FROM (1000) TO (2000)
+    )")
+      .maybeThrow();
+
+  SchemaDiscovery discovery(sqlConnection.get());
+
+  auto tables = discovery.discoverTables();
+  bool found_partitioned = false;
+  for (const auto &table : tables) {
+    if (table.name == "test_partitioned") {
+      found_partitioned = true;
+      REQUIRE(table.table_type == metadata::Table::Type::partitioned);
+      REQUIRE(table.partition_type == schema_discovery::PartitionType::range);
+      break;
+    }
+  }
+  REQUIRE(found_partitioned);
+
+  auto partitions = discovery.discoverPartitions("test_partitioned");
+  REQUIRE(partitions.size() == 2);
+
+  auto find_partition =
+      [&partitions](const std::string &name) -> const DiscoveredPartition * {
+    auto it = std::find_if(
+        partitions.begin(), partitions.end(),
+        [&name](const DiscoveredPartition &p) { return p.name == name; });
+    return it != partitions.end() ? &(*it) : nullptr;
+  };
+
+  auto p0 = find_partition("test_partitioned_p0");
+  REQUIRE(p0 != nullptr);
+  REQUIRE_THAT(p0->partition_bound, Catch::Matchers::ContainsSubstring("0"));
+  REQUIRE_THAT(p0->partition_bound, Catch::Matchers::ContainsSubstring("1000"));
+
+  auto p1 = find_partition("test_partitioned_p1");
+  REQUIRE(p1 != nullptr);
+  REQUIRE_THAT(p1->partition_bound, Catch::Matchers::ContainsSubstring("1000"));
+  REQUIRE_THAT(p1->partition_bound, Catch::Matchers::ContainsSubstring("2000"));
+}
+
+TEST_CASE_METHOD(SchemaDiscoveryFixture,
+                 "SchemaDiscovery - Foreign key discovery",
+                 "[schema_discovery]") {
+  REQUIRE(sqlConnection != nullptr);
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE parent_table (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR(100) NOT NULL
+        )
+    )")
+      .maybeThrow();
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE child_table (
+            id SERIAL PRIMARY KEY,
+            parent_id INT NOT NULL,
+            description TEXT,
+            FOREIGN KEY (parent_id) REFERENCES parent_table(id)
+        )
+    )")
+      .maybeThrow();
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE parent_composite (
+            tenant_id INT,
+            entity_id INT,
+            name VARCHAR(100),
+            PRIMARY KEY (tenant_id, entity_id)
+        )
+    )")
+      .maybeThrow();
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE child_composite (
+            id SERIAL PRIMARY KEY,
+            parent_tenant_id INT NOT NULL,
+            parent_entity_id INT NOT NULL,
+            description TEXT,
+            FOREIGN KEY (parent_tenant_id, parent_entity_id) REFERENCES parent_composite(tenant_id, entity_id)
+        )
+    )")
+      .maybeThrow();
+
+  SchemaDiscovery discovery(sqlConnection.get());
+
+  auto child_constraints = discovery.discoverConstraints("child_table");
+  REQUIRE(child_constraints.size() >= 2); // at least PK and FK
+
+  auto find_constraint =
+      [&child_constraints](schema_discovery::ConstraintType type)
+      -> const DiscoveredConstraint * {
+    auto it = std::find_if(
+        child_constraints.begin(), child_constraints.end(),
+        [&type](const DiscoveredConstraint &c) { return c.type == type; });
+    return it != child_constraints.end() ? &(*it) : nullptr;
+  };
+
+  auto fk_constraint =
+      find_constraint(schema_discovery::ConstraintType::foreign_key);
+  REQUIRE(fk_constraint != nullptr);
+  REQUIRE(fk_constraint->columns.size() == 1);
+  REQUIRE(fk_constraint->columns[0] == "parent_id");
+  REQUIRE(fk_constraint->referenced_table == "parent_table");
+  REQUIRE(fk_constraint->referenced_columns.size() == 1);
+  REQUIRE(fk_constraint->referenced_columns[0] == "id");
+
+  auto composite_constraints = discovery.discoverConstraints("child_composite");
+  REQUIRE(composite_constraints.size() >= 2); // at least PK and FK
+
+  auto composite_fk = std::find_if(
+      composite_constraints.begin(), composite_constraints.end(),
+      [](const DiscoveredConstraint &c) {
+        return c.type == schema_discovery::ConstraintType::foreign_key;
+      });
+  REQUIRE(composite_fk != composite_constraints.end());
+  REQUIRE(composite_fk->columns.size() == 2);
+  REQUIRE(std::find(composite_fk->columns.begin(), composite_fk->columns.end(),
+                    "parent_tenant_id") != composite_fk->columns.end());
+  REQUIRE(std::find(composite_fk->columns.begin(), composite_fk->columns.end(),
+                    "parent_entity_id") != composite_fk->columns.end());
+  REQUIRE(composite_fk->referenced_table == "parent_composite");
+  REQUIRE(composite_fk->referenced_columns.size() == 2);
+  REQUIRE(std::find(composite_fk->referenced_columns.begin(),
+                    composite_fk->referenced_columns.end(),
+                    "tenant_id") != composite_fk->referenced_columns.end());
+  REQUIRE(std::find(composite_fk->referenced_columns.begin(),
+                    composite_fk->referenced_columns.end(),
+                    "entity_id") != composite_fk->referenced_columns.end());
+}
+
+TEST_CASE_METHOD(SchemaDiscoveryFixture, "SchemaDiscovery - Empty database",
+                 "[schema_discovery]") {
+  REQUIRE(sqlConnection != nullptr);
+
+  SchemaDiscovery discovery(sqlConnection.get());
+  auto tables = discovery.discoverTables();
+
+  REQUIRE(tables.empty());
+}

--- a/libstormweaver/test/sql/worker_schema_discovery.cpp
+++ b/libstormweaver/test/sql/worker_schema_discovery.cpp
@@ -1,0 +1,358 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <spdlog/spdlog.h>
+
+#include "sql.hpp"
+#include "workload.hpp"
+
+// Fixture to ensure clean database state for each test
+class WorkerSchemaDiscoveryFixture {
+public:
+  WorkerSchemaDiscoveryFixture() {
+    // Recreate public schema to ensure clean state
+    sqlConnection->executeQuery("DROP SCHEMA IF EXISTS public CASCADE")
+        .maybeThrow();
+    sqlConnection->executeQuery("CREATE SCHEMA public").maybeThrow();
+    sqlConnection->executeQuery("GRANT ALL ON SCHEMA public TO public")
+        .maybeThrow();
+  }
+
+  ~WorkerSchemaDiscoveryFixture() {
+    // Clean up is automatic via schema recreation in next test
+  }
+};
+
+TEST_CASE_METHOD(WorkerSchemaDiscoveryFixture,
+                 "Worker - Schema discovery basic workflow",
+                 "[worker_schema_discovery]") {
+  REQUIRE(sqlConnection != nullptr);
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE test_worker_basic (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR(100) NOT NULL,
+            price REAL,
+            active BOOLEAN DEFAULT TRUE
+        )
+    )")
+      .maybeThrow();
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE test_worker_indexed (
+            id SERIAL PRIMARY KEY,
+            email VARCHAR(255) UNIQUE,
+            name VARCHAR(100),
+            age INT
+        )
+    )")
+      .maybeThrow();
+
+  sqlConnection
+      ->executeQuery(
+          "CREATE INDEX idx_worker_name ON test_worker_indexed (name)")
+      .maybeThrow();
+  sqlConnection
+      ->executeQuery("CREATE INDEX idx_worker_age_desc ON test_worker_indexed "
+                     "(name, age DESC)")
+      .maybeThrow();
+
+  sql_variant::ServerParams params{"sql_tests",   "127.0.0.1", "",
+                                   "stormweaver", "",          25432};
+
+  SqlFactory::on_connect_t empty_callback;
+  SqlFactory factory(params, empty_callback);
+
+  auto logger =
+      spdlog::get("test") ? spdlog::get("test") : spdlog::default_logger();
+  LuaContext luaCtx(logger);
+
+  auto metadata = std::make_shared<metadata::Metadata>();
+  WorkloadParams wp;
+
+  auto worker = std::make_unique<Worker>(
+      "test-worker",
+      [&factory, &luaCtx]() { return factory.connect("test-worker", luaCtx); },
+      wp, metadata);
+
+  REQUIRE(metadata->size() == 0);
+
+  worker->discover_existing_schema();
+
+  REQUIRE(metadata->size() == 2);
+
+  auto find_table =
+      [&metadata](const std::string &name) -> metadata::table_cptr {
+    for (std::size_t i = 0; i < metadata->size(); ++i) {
+      auto table = (*metadata)[i];
+      if (table && table->name == name) {
+        return table;
+      }
+    }
+    return nullptr;
+  };
+
+  auto basic_table = find_table("test_worker_basic");
+  REQUIRE(basic_table != nullptr);
+  REQUIRE(basic_table->columns.size() == 4);
+  REQUIRE(basic_table->engine == "");
+
+  auto indexed_table = find_table("test_worker_indexed");
+  REQUIRE(indexed_table != nullptr);
+  REQUIRE(indexed_table->columns.size() == 4);
+  REQUIRE(indexed_table->indexes.size() ==
+          3); // unique constraint + 2 explicit indexes
+
+  auto find_column = [](const metadata::table_cptr &table,
+                        const std::string &name) -> const metadata::Column * {
+    auto it = std::find_if(
+        table->columns.begin(), table->columns.end(),
+        [&name](const metadata::Column &col) { return col.name == name; });
+    return it != table->columns.end() ? &(*it) : nullptr;
+  };
+
+  auto id_col = find_column(basic_table, "id");
+  REQUIRE(id_col != nullptr);
+  REQUIRE(id_col->primary_key == true);
+  REQUIRE(id_col->auto_increment == true);
+  REQUIRE(id_col->nullable == false);
+
+  auto find_index = [](const metadata::table_cptr &table,
+                       const std::string &name) -> const metadata::Index * {
+    auto it = std::find_if(
+        table->indexes.begin(), table->indexes.end(),
+        [&name](const metadata::Index &idx) { return idx.name == name; });
+    return it != table->indexes.end() ? &(*it) : nullptr;
+  };
+
+  auto desc_index = find_index(indexed_table, "idx_worker_age_desc");
+  REQUIRE(desc_index != nullptr);
+  REQUIRE(desc_index->fields.size() == 2);
+  REQUIRE(desc_index->fields[0].column_name == "name");
+  REQUIRE(desc_index->fields[1].column_name == "age");
+  REQUIRE(desc_index->fields[0].ordering == metadata::IndexOrdering::asc);
+  REQUIRE(desc_index->fields[1].ordering == metadata::IndexOrdering::desc);
+}
+
+TEST_CASE_METHOD(WorkerSchemaDiscoveryFixture,
+                 "Worker - Schema discovery with partitioned table",
+                 "[worker_schema_discovery]") {
+  REQUIRE(sqlConnection != nullptr);
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE test_worker_partitioned (
+            id SERIAL,
+            partition_key INT,
+            data TEXT
+        ) PARTITION BY RANGE (partition_key)
+    )")
+      .maybeThrow();
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE test_worker_partitioned_p0 PARTITION OF test_worker_partitioned 
+        FOR VALUES FROM (0) TO (1000)
+    )")
+      .maybeThrow();
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE test_worker_partitioned_p1 PARTITION OF test_worker_partitioned 
+        FOR VALUES FROM (1000) TO (2000)
+    )")
+      .maybeThrow();
+
+  sql_variant::ServerParams params{"sql_tests",   "127.0.0.1", "",
+                                   "stormweaver", "",          25432};
+
+  SqlFactory::on_connect_t empty_callback;
+  SqlFactory factory(params, empty_callback);
+
+  auto logger =
+      spdlog::get("test") ? spdlog::get("test") : spdlog::default_logger();
+  LuaContext luaCtx(logger);
+  auto metadata = std::make_shared<metadata::Metadata>();
+  WorkloadParams wp;
+
+  auto worker = std::make_unique<Worker>(
+      "test-worker-partitioned",
+      [&factory, &luaCtx]() {
+        return factory.connect("test-worker-partitioned", luaCtx);
+      },
+      wp, metadata);
+
+  worker->discover_existing_schema();
+
+  REQUIRE(metadata->size() == 1);
+
+  auto table = (*metadata)[0];
+  REQUIRE(table != nullptr);
+  REQUIRE(table->name == "test_worker_partitioned");
+
+  REQUIRE(table->partitioning.has_value());
+  REQUIRE(table->partitioning->ranges.size() == 2);
+
+  bool found_p0 = false, found_p1 = false;
+  for (const auto &range : table->partitioning->ranges) {
+    if (range.rangebase == 0)
+      found_p0 = true;
+    if (range.rangebase == 1)
+      found_p1 = true;
+  }
+  REQUIRE(found_p0);
+  REQUIRE(found_p1);
+}
+
+TEST_CASE_METHOD(WorkerSchemaDiscoveryFixture,
+                 "Worker - Schema discovery with empty database",
+                 "[worker_schema_discovery]") {
+  REQUIRE(sqlConnection != nullptr);
+
+  sql_variant::ServerParams params{"sql_tests",   "127.0.0.1", "",
+                                   "stormweaver", "",          25432};
+
+  SqlFactory::on_connect_t empty_callback;
+  SqlFactory factory(params, empty_callback);
+
+  auto logger =
+      spdlog::get("test") ? spdlog::get("test") : spdlog::default_logger();
+  LuaContext luaCtx(logger);
+  auto metadata = std::make_shared<metadata::Metadata>();
+  WorkloadParams wp;
+
+  auto worker = std::make_unique<Worker>(
+      "test-worker-empty",
+      [&factory, &luaCtx]() {
+        return factory.connect("test-worker-empty", luaCtx);
+      },
+      wp, metadata);
+
+  worker->discover_existing_schema();
+
+  REQUIRE(metadata->size() == 0);
+}
+
+TEST_CASE_METHOD(WorkerSchemaDiscoveryFixture,
+                 "Worker - Schema discovery successful workflow",
+                 "[worker_schema_discovery]") {
+  REQUIRE(sqlConnection != nullptr);
+
+  sqlConnection
+      ->executeQuery(R"(
+        CREATE TABLE test_worker_simple (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR(100)
+        )
+    )")
+      .maybeThrow();
+
+  sql_variant::ServerParams params{"sql_tests",   "127.0.0.1", "",
+                                   "stormweaver", "",          25432};
+
+  SqlFactory::on_connect_t empty_callback;
+  SqlFactory factory(params, empty_callback);
+
+  auto logger =
+      spdlog::get("test") ? spdlog::get("test") : spdlog::default_logger();
+  LuaContext luaCtx(logger);
+  auto metadata = std::make_shared<metadata::Metadata>();
+  WorkloadParams wp;
+
+  auto worker = std::make_unique<Worker>(
+      "test-worker-simple",
+      [&factory, &luaCtx]() {
+        return factory.connect("test-worker-simple", luaCtx);
+      },
+      wp, metadata);
+
+  REQUIRE_NOTHROW(worker->discover_existing_schema());
+
+  REQUIRE(metadata->size() == 1);
+  auto table = (*metadata)[0];
+  REQUIRE(table != nullptr);
+  REQUIRE(table->name == "test_worker_simple");
+}
+
+TEST_CASE("Worker - Reset metadata functionality", "[worker_reset_metadata]") {
+  sql_variant::ServerParams params{"sql_tests",   "127.0.0.1", "",
+                                   "stormweaver", "",          25432};
+
+  SqlFactory::on_connect_t empty_callback;
+  SqlFactory factory(params, empty_callback);
+
+  auto logger =
+      spdlog::get("test") ? spdlog::get("test") : spdlog::default_logger();
+  LuaContext luaCtx(logger);
+  auto metadata = std::make_shared<metadata::Metadata>();
+  WorkloadParams wp;
+
+  auto worker = std::make_unique<Worker>(
+      "test-worker-reset",
+      [&factory, &luaCtx]() {
+        return factory.connect("test-worker-reset", luaCtx);
+      },
+      wp, metadata);
+
+  auto connection = worker->sql_connection();
+  REQUIRE(connection != nullptr);
+
+  connection
+      ->executeQuery(R"(
+        CREATE TABLE IF NOT EXISTS test_reset_table (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR(100)
+        )
+    )")
+      .maybeThrow();
+
+  worker->discover_existing_schema();
+  REQUIRE(metadata->size() >= 1);
+
+  worker->reset_metadata();
+  REQUIRE(metadata->size() == 0);
+
+  worker->discover_existing_schema();
+  REQUIRE(metadata->size() >= 1);
+}
+
+TEST_CASE("Worker - Metadata validation functionality",
+          "[worker_validate_metadata]") {
+  // Note: This test uses a different port to avoid conflicts with other tests
+  sql_variant::ServerParams params{"sql_tests",   "127.0.0.1", "",
+                                   "stormweaver", "",          25432};
+
+  SqlFactory::on_connect_t empty_callback;
+  SqlFactory factory(params, empty_callback);
+
+  auto logger =
+      spdlog::get("test") ? spdlog::get("test") : spdlog::default_logger();
+  LuaContext luaCtx(logger);
+  auto metadata = std::make_shared<metadata::Metadata>();
+  WorkloadParams wp;
+
+  auto worker = std::make_unique<Worker>(
+      "test-worker-validate",
+      [&factory, &luaCtx]() {
+        return factory.connect("test-worker-validate", luaCtx);
+      },
+      wp, metadata);
+
+  auto connection = worker->sql_connection();
+  REQUIRE(connection != nullptr);
+
+  connection
+      ->executeQuery(R"(
+        CREATE TABLE IF NOT EXISTS test_validation_table (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR(100) NOT NULL
+        )
+    )")
+      .maybeThrow();
+
+  worker->discover_existing_schema();
+  REQUIRE(metadata->size() >= 1);
+
+  REQUIRE(worker->validate_metadata());
+}

--- a/tests/metadata_validation.lua
+++ b/tests/metadata_validation.lua
@@ -1,0 +1,48 @@
+-- Work in progress testcase / helper script for metadata validation
+-- As currently it's not perfect, this can't be a proper automatic test, as it fails
+
+require("common")
+require("entropy")
+
+function db_setup(worker)
+	worker:create_random_tables(5)
+end
+
+function conn_settings(sqlconn) end
+
+function main(argv)
+	default_ref = defaultActionRegistry()
+
+	default_ref:makeCustomTableSqlAction("vacuum_full_table", "VACUUM FULL {table};", 2)
+
+	args = argparser:parse(argv)
+	conffile = parse_config(args)
+
+	pgconfig = PgConf.new(conffile["default"])
+
+	pgm = PgManager.new(pgconfig)
+	pgm:setupAndStartPrimary(conn_settings, { shared_preload_libraries = "pg_tde" })
+
+	default_ref:makeCustomTableSqlAction("truncate_table", "TRUNCATE {table};", 2)
+
+	pgm.primaryNode:init(db_setup)
+
+	pgm.primaryNode:possibleActions():makeCustomTableSqlAction("reindex", "REINDEX TABLE {table};", 1)
+
+	params = WorkloadParams.new()
+	params.duration_in_seconds = 10
+	params.number_of_workers = 1
+	t1 = pgm.primaryNode:initRandomWorkload(params)
+
+	for workloadIdx = 1, 500 do
+		t1:run()
+		pgm:get(1):restart(10)
+
+		w = pgm.primaryNode:make_worker("verification")
+		if not w:validate_metadata() then
+			error("Internal erorr, metadata validation failed: either metadata or metadata_populator bug")
+		end
+	end
+
+	pgm:get(1):stop(10)
+end


### PR DESCRIPTION
This commit adds Stormweaver the capability to:

1. load the metadata structure from an existing database instead of relying on the in memory structure
2. adds a function to the lua interface which validates that the current metadata and the one in the database is the same

There's also a test script based on the validation function, but it's only used for development for now, as there are some remaining issues with the validation. Some of the issues might be still inonsistencies in the in-memory metadata structure, while others are Postgres specifics that either have to be ignored or handled specially (for example it's possible that CREATE INDEX CONCURRENTLY succeeds, but the index fails later, and then after some DDL operations it's automatically deleted)

But even with these limitations, this is a useful feature for testing backup/restore with DDL operations involved.

The code is mostly Claude generated, but it has extensive test coverage and was checked/tested properly.