### PR TITLE
Fixing note boxes in documentation

### DIFF
--- a/docs/config-parameters.md
+++ b/docs/config-parameters.md
@@ -4,10 +4,10 @@ StormWeaver supports configuration through multiple layers with a clear preceden
 
 !!! Note
 
-  Configuration parameters are parsed by Lua scenario scripts.
-  The C++ runner only passes the command-line parameters to the scenario, and provides an API for accessing all configuration options.
+    Configuration parameters are parsed by Lua scenario scripts.
+    The C++ runner only passes the command-line parameters to the scenario, and provides an API for accessing all configuration options.
   
-  Custom (external) scenario files might work differently.
+    Custom (external) scenario files might work differently.
 
 ## TOML Configuration File
 

--- a/docs/extensibility-workflow.md
+++ b/docs/extensibility-workflow.md
@@ -99,9 +99,9 @@ private:
 
 !!! Note
 
-  The above example showcases a completely new action type in a new source file.
-  When appropriate, edit existing files, such as ddl.hpp/cpp or dml.hpp/cpp.
-  When editing existing files, it is usually better to extend the existing configuration struct instead of defining a new struct.
+    The above example showcases a completely new action type in a new source file.
+    When appropriate, edit existing files, such as ddl.hpp/cpp or dml.hpp/cpp.
+    When editing existing files, it is usually better to extend the existing configuration struct instead of defining a new struct.
 
 **Step 2: Implement Action Logic**
 ```cpp

--- a/docs/lua-cpp-reference.md
+++ b/docs/lua-cpp-reference.md
@@ -451,7 +451,7 @@ The optional wrapper and wrapperArgs parameters allow running PostgreSQL through
 
 !!! note
 
-  The wrapper parameter doesn't take `$PATH` into account, it requires a full filename
+    The wrapper parameter doesn't take `$PATH` into account, it requires a full filename
 
 ### stop
 
@@ -477,7 +477,7 @@ The optional wrapper and wrapperArgs parameters allow running PostgreSQL through
 
 !!! note
 
-  The wrapper parameter doesn't take `$PATH` into account, it requires a full filename
+    The wrapper parameter doesn't take `$PATH` into account, it requires a full filename
 
 ### kill9
 


### PR DESCRIPTION
The markdown format requres 4 spaces for them to work properly, but some placaes only had 2, resulting in the text being displayed after the box instead of in.