### PR TITLE
Introduce a simple runner script 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/LebJe/toml.lua.git
 [submodule "_3p-lua/argparse"]
 	path = _3p-lua/argparse
-	url = https://github.com/mpeterv/argparse
+	url = https://github.com/luarocks/argparse
 [submodule "_3p-lua/luafilesystem"]
 	path = _3p-lua/luafilesystem
 	url = https://github.com/lunarmodules/luafilesystem

--- a/scenarios/ci/basic.lua
+++ b/scenarios/ci/basic.lua
@@ -1,0 +1,16 @@
+require("pg_simple")
+
+function main(argv)
+	simple_pg_single(argv, function(args)
+		for workloadIdx = 1, tonumber(args["repeat"]) do
+			t1:run()
+			t1:wait_completion()
+			pgm:get(1):restart(10)
+
+			w = pgm.primaryNode:make_worker("verification")
+			db_files_entropy(w, "datadirs/datadir_pr/")
+		end
+
+		pgm:get(1):stop(10)
+	end)
+end

--- a/scripts/argparser.lua
+++ b/scripts/argparser.lua
@@ -2,7 +2,7 @@ local argparse = require("argparse")
 
 argparser = argparse("stormweaver", "")
 argparser:argument("scenario", "Scenario file")
-argparser:option("-c --config", "Configuration file.", "config/stormweaver.toml")
+argparser:option("-c --config", "Configuration file", "config/stormweaver.toml")
 argparser:option(
 	"-i --install_dir",
 	"PostgreSQL installation directory (if specified, overrides configuration value for default server)",

--- a/scripts/pg_simple.lua
+++ b/scripts/pg_simple.lua
@@ -1,0 +1,71 @@
+require("common")
+require("entropy")
+
+use_tde = false
+
+function db_setup(worker)
+	if use_tde then
+		init_pg_tde_only_for_db(worker:sql_connection())
+	end
+	worker:create_random_tables(5)
+end
+
+function conn_settings(sqlconn)
+	if use_tde then
+		sqlconn:execute_query("SET default_table_access_method=tde_heap;")
+	end
+end
+
+function add_standard_actions(reg)
+	reg:makeCustomSqlAction("checkpoint", "CHECKPOINT;", 10)
+	reg:makeCustomTableSqlAction("vacuum_full_table", "VACUUM FULL {table};", 20)
+	reg:makeCustomTableSqlAction("truncate_table", "TRUNCATE {table};", 20)
+	reg:makeCustomTableSqlAction("reindex_table", "REINDEX TABLE {table};", 20)
+end
+
+argparser:option("-d --duration", "Duration in seconds", "10")
+argparser:option("-w --workers", "Number of workers", "5")
+argparser:option("-r --repeat", "Number of workloads / repeats", "50")
+
+argparser:option("--tde")({
+	choices = { "on", "off" },
+	default = "on",
+})
+argparser:option("--pgsm")({
+	choices = { "on", "off" },
+	default = "off",
+})
+
+function simple_pg_single(argv, test)
+	args = argparser:parse(argv)
+
+	default_reg = defaultActionRegistry()
+	add_standard_actions(default_reg)
+
+	conffile = parse_config(args)
+	pgconfig = PgConf.new(conffile["default"])
+	pgm = PgManager.new(pgconfig)
+
+	additional_settings = { shared_preload_libraries = "" }
+
+	if args["tde"] == "on" then
+		info("Running tests with pg_tde")
+		use_tde = true
+		additional_settings["shared_preload_libraries"] = additional_settings["shared_preload_libraries"] .. "pg_tde"
+	end
+	if args["pgsm"] == "on" then
+		info("Running tests with pg_stat_monitor")
+		additional_settings["shared_preload_libraries"] = additional_settings["shared_preload_libraries"]
+			.. "pg_stat_monitor"
+	end
+
+	pgm:setupAndStartPrimary(conn_settings, additional_settings)
+	pgm.primaryNode:init(db_setup)
+
+	params = WorkloadParams.new()
+	params.duration_in_seconds = tonumber(args["duration"])
+	params.number_of_workers = tonumber(args["workers"])
+	t1 = pgm.primaryNode:initRandomWorkload(params)
+
+	test(args)
+end


### PR DESCRIPTION
This commit "refactors" the basic testcase into two files:

* A simplified runner which handles all the common setup logic, which
  makes it easier and cleaner to create many specific tests, such as
  different backup scenarios
* A minimal script that implements the basic example using this new
  helper. This is now in the "ci" folder, with the intention to move
  scripts that are intended to be run as github actions in the postgres
  repo there.
  This also separates the "example" basic script, and the CI task we
  currently use.