### PR TITLE
Added merge gatekeeper

### DIFF
--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -1,0 +1,20 @@
+---
+name: Merge Gatekeeper
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  merge-gatekeeper:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      statuses: read
+    steps:
+      - name: Run Merge Gatekeeper
+        uses: upsidr/merge-gatekeeper@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          timeout: 3600


### PR DESCRIPTION
This is just a simple workflow action that allows us to improve the merge rules: github currently doesn't support required workflows with path filter properly, as it always waits for the job to complete, even if it is skipped because of the filters.

With gatekeeper instead we can make just the gatekeeper a required job, and it will fail if any other jobs fail.