### PR TITLE
Workload bugfix: actionfactory might change

### DIFF
--- a/libstormweaver/include/action/action_registry.hpp
+++ b/libstormweaver/include/action/action_registry.hpp
@@ -45,7 +45,7 @@ public:
   std::size_t totalWeight() const;
   bool has(std::string name) const;
 
-  ActionFactory const &lookupByWeightOffset(std::size_t offset) const;
+  ActionFactory lookupByWeightOffset(std::size_t offset) const;
 
 private:
   std::vector<ActionFactory> factories;

--- a/libstormweaver/src/action/action_registry.cpp
+++ b/libstormweaver/src/action/action_registry.cpp
@@ -242,8 +242,7 @@ bool ActionRegistry::has(std::string name) const {
   return it != factories.end();
 }
 
-ActionFactory const &
-ActionRegistry::lookupByWeightOffset(std::size_t offset) const {
+ActionFactory ActionRegistry::lookupByWeightOffset(std::size_t offset) const {
   std::unique_lock<std::mutex> lk(mutex);
 
   std::size_t accum = 0;

--- a/libstormweaver/src/workload.cpp
+++ b/libstormweaver/src/workload.cpp
@@ -150,7 +150,7 @@ void RandomWorker::run_thread(std::size_t duration_in_seconds) {
         static_cast<int64_t>(duration_in_seconds)) {
 
       const auto w = rand.random_number(std::size_t(0), actions.totalWeight());
-      const auto &actionFactory = actions.lookupByWeightOffset(w);
+      const auto actionFactory = actions.lookupByWeightOffset(w);
       auto action = actionFactory.builder(config.actionConfig);
 
       stats.startAction(actionFactory.name);


### PR DESCRIPTION
ActionFactory::lookupByWeightOffset returned a const&, and according to this the RandomWorker workload code stored a const& as a local variable to the current action.

In the meantime in the basic.lua scenario we change the ActionFactory of one of the workers to show that it is possible. This is completely valid usecase, but it also shift the storage in the ActionFactory, invalidating any active references.

This materialized as a flaky CI runs where sometimes the worker started one action in the statistics, but tried to stop another, failing with a logic_exception.

The fix is quite simple, this method and its local variable counterpart shouldn't be a reference.