### PR TITLE
PG-1711: Incremental backup testcase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /bin/
 /logs/
 /datadirs/
+/backups/

--- a/libstormweaver/include/process/postgres.hpp
+++ b/libstormweaver/include/process/postgres.hpp
@@ -18,10 +18,10 @@ public:
   using args_t = std::vector<std::string>;
 
   Postgres(bool initDatadir, std::string const &logname,
-           std::string const &installDir, std::string const &dataDir);
+           std::string const &installDir, std::string const &datadir);
 
   Postgres(std::string const &logname, std::string const &installDir,
-           std::string const &dataDir, sql_variant::ServerParams const &from,
+           std::string const &datadir, sql_variant::ServerParams const &from,
            args_t additionalParams);
 
   ~Postgres();
@@ -42,6 +42,8 @@ public:
 
   void kill9();
 
+  bool basebackup(args_t args);
+
   bool createdb(std::string const &name);
 
   bool createuser(std::string const &name, args_t args);
@@ -56,9 +58,11 @@ public:
 
   std::string serverPort() const;
 
+  std::filesystem::path dataDir() const;
+
 private:
   std::filesystem::path installDir;
-  std::filesystem::path dataDir;
+  std::filesystem::path dataDir_;
   std::string port;
 
   std::shared_ptr<spdlog::logger> logger;

--- a/libstormweaver/src/checksum.cpp
+++ b/libstormweaver/src/checksum.cpp
@@ -38,6 +38,10 @@ void DatabaseChecksum::calculateAllTableChecksums() {
 
     results_.push_back(result);
   }
+
+  std::sort(results_.begin(), results_.end(), [](auto const &a, auto const &b) {
+    return a.tableName < b.tableName;
+  });
 }
 
 void DatabaseChecksum::writeResultsToFile(const std::string &filename) {

--- a/scenarios/basic.lua
+++ b/scenarios/basic.lua
@@ -92,12 +92,12 @@ function main(argv)
 		t1:wait_completion()
 
 		-- restart the server, workers will automatically reconnect
-		pgm:get(1):restart(10)
+		pgm:restart(1, 10)
 
 		w = pgm.primaryNode:make_worker("verification")
 
 		db_files_entropy(w, "datadirs/datadir_pr/")
 	end
 
-	pgm:get(1):stop(10)
+	pgm:stop(1, 10)
 end

--- a/scenarios/ci/incremental.lua
+++ b/scenarios/ci/incremental.lua
@@ -1,0 +1,61 @@
+require("pg_simple")
+
+function main(argv)
+	if fs.is_directory("backups") then
+		warning("Deleting old stormweaver run backups")
+		fs.delete_directory("backups")
+	end
+
+	simple_pg_single(argv, function(args)
+		pgm:basebackup(1, "-D", "backups/backup_0", "-U", "stormweaver", "-c", "fast")
+
+		for workloadIdx = 1, tonumber(args["repeat"]) do
+			t1:run()
+			t1:wait_completion()
+			pgm:get(1, 10)
+
+			prevBackupDir = "backups/backup_" .. tostring(workloadIdx - 1)
+			backupDir = "backups/backup_" .. tostring(workloadIdx)
+
+			pgm:basebackup(
+				1,
+				"-D",
+				backupDir,
+				"-U",
+				"stormweaver",
+				"-c",
+				"fast",
+				"-i",
+				prevBackupDir .. "/backup_manifest"
+			)
+
+			w = pgm.primaryNode:make_worker("verification")
+			w:calculate_database_checksums(backupDir .. ".checksum")
+		end
+
+		combine = { "-o", "datadirs/datadir_pr" }
+		table.insert(combine, "backups/backup_0")
+
+		for workloadIdx = 1, tonumber(args["repeat"]) do
+			info("Restoring and verifying incremental #" .. tostring(workloadIdx))
+			pgm:stop(1, 10)
+			fs.delete_directory("datadirs/datadir_pr")
+
+			table.insert(combine, "backups/backup_" .. tostring(workloadIdx))
+			pgm:combinebackup(table.unpack(combine))
+			pgm:start(1)
+
+			backupChecksumFile = "backups/backup_" .. tostring(workloadIdx) .. ".checksum"
+			checksumFile = "datadirs/datadir_pr/db.checksum"
+			w = pgm.primaryNode:make_worker("reset")
+			w:reset_metadata()
+			w:discover_existing_schema()
+			w:calculate_database_checksums(checksumFile)
+
+			bp = BackgroundProcess.start("checksumdiff", "/usr/bin/diff", checksumFile, backupChecksumFile)
+			if not bp:waitUntilExits() then
+				error("Backup checksum verification failed with incremental #" .. tostring(workloadIdx))
+			end
+		end
+	end)
+end

--- a/scripts/pg_simple.lua
+++ b/scripts/pg_simple.lua
@@ -4,14 +4,17 @@ require("entropy")
 use_tde = false
 
 function db_setup(worker)
-	if use_tde then
+	if use_tde == "on" then
 		init_pg_tde_only_for_db(worker:sql_connection())
+	end
+	if use_tde == "on_wal" then
+		init_pg_tde_globally(worker:sql_connection())
 	end
 	worker:create_random_tables(5)
 end
 
 function conn_settings(sqlconn)
-	if use_tde then
+	if use_tde ~= "off" then
 		sqlconn:execute_query("SET default_table_access_method=tde_heap;")
 	end
 end
@@ -28,7 +31,7 @@ argparser:option("-w --workers", "Number of workers", "5")
 argparser:option("-r --repeat", "Number of workloads / repeats", "50")
 
 argparser:option("--tde")({
-	choices = { "on", "off" },
+	choices = { "on", "on_wal", "off" },
 	default = "on",
 })
 argparser:option("--pgsm")({
@@ -36,8 +39,15 @@ argparser:option("--pgsm")({
 	default = "off",
 })
 
+argparser:flag("--clear-logs")
+
 function simple_pg_single(argv, test)
 	args = argparser:parse(argv)
+
+	if args["clear_logs"] then
+		info("Clearing old log files")
+		fs.delete_directory("logs")
+	end
 
 	default_reg = defaultActionRegistry()
 	add_standard_actions(default_reg)
@@ -46,11 +56,11 @@ function simple_pg_single(argv, test)
 	pgconfig = PgConf.new(conffile["default"])
 	pgm = PgManager.new(pgconfig)
 
-	additional_settings = { shared_preload_libraries = "" }
+	additional_settings = { shared_preload_libraries = "", summarize_wal = "on" }
 
-	if args["tde"] == "on" then
-		info("Running tests with pg_tde")
-		use_tde = true
+	if args["tde"] ~= "off" then
+		info("Running tests with pg_tde = " .. args["tde"])
+		use_tde = args["tde"]
 		additional_settings["shared_preload_libraries"] = additional_settings["shared_preload_libraries"] .. "pg_tde"
 	end
 	if args["pgsm"] == "on" then
@@ -61,6 +71,8 @@ function simple_pg_single(argv, test)
 
 	pgm:setupAndStartPrimary(conn_settings, additional_settings)
 	pgm.primaryNode:init(db_setup)
+
+	pgm:restart(1, 10) -- Restart as init can potentially use ALTER SYSTEM
 
 	params = WorkloadParams.new()
 	params.duration_in_seconds = tonumber(args["duration"])

--- a/scripts/tde_helper.lua
+++ b/scripts/tde_helper.lua
@@ -12,6 +12,7 @@ function init_pg_tde_globally(sqlconn)
 	sqlconn:execute_query("SELECT pg_tde_add_global_key_provider_file('reg_file', '/tmp/pg_tde_test_keyring.per');")
 	sqlconn:execute_query("SELECT pg_tde_create_key_using_global_key_provider('server-principal-key', 'reg_file');")
 	sqlconn:execute_query("SELECT pg_tde_set_key_using_global_key_provider('server-principal-key', 'reg_file');")
+	sqlconn:execute_query("SELECT pg_tde_set_server_key_using_global_key_provider('server-principal-key', 'reg_file');")
 	sqlconn:execute_query("SELECT pg_tde_set_default_key_using_global_key_provider('def-principal-key', 'reg_file');")
-	--sqlconn:execute_query("ALTER SYSTEM SET pg_Tde.wal_encrypt = ON;")
+	sqlconn:execute_query("ALTER SYSTEM SET pg_Tde.wal_encrypt = ON;")
 end


### PR DESCRIPTION
This commit adds the required infrastructure for testing incremental backups, and also adds a simple testcase using the simple scenario framework to run incremental backups with various tde configurations.

The testcase verifies that:

1. incremental backup and restore works and completes successfully
2. table checksums taken just before the backups, and after restore are exactly the same

This change also adds the option to run the single runner with WAL encryption (--tde=on_wal), but this doesn't yet work with incremental backups, as startup after combinebackup fails.

The commit also contains some related refactoring / debugging improvements.